### PR TITLE
add instructions to pip install from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Superset and Preset workspaces efficiently.
 ```bash
 pip install superset-sup
 ```
+OR
+```bash
+pip install git+https://github.com/preset-io/superset-sup.git
+```
 
 ### Getting Started
 


### PR DESCRIPTION
Until we publish on PyPI, let's give people the other install option.