### PR TITLE
feat: implement security & governance commands for sup CLI

### DIFF
--- a/src/sup/commands/ownership.py
+++ b/src/sup/commands/ownership.py
@@ -150,7 +150,6 @@ def import_ownership(
         get_logs,
         write_logs_to_file,
     )
-
     from sup.clients.superset import SupSupersetClient
     from sup.config.settings import SupContext
     from sup.output.spinners import spinner
@@ -211,8 +210,7 @@ def import_ownership(
             with open(log_file_path, "w", encoding="utf-8") as log_file:
                 for resource_name, resources in config.items():
                     resource_ids = {
-                        str(v): k
-                        for k, v in client.client.get_uuids(resource_name).items()
+                        str(v): k for k, v in client.client.get_uuids(resource_name).items()
                     }
 
                     for ownership in resources:

--- a/src/sup/commands/ownership.py
+++ b/src/sup/commands/ownership.py
@@ -1,7 +1,7 @@
 """
 Asset ownership management commands for sup CLI.
 
-Handles export and import of dataset, chart, and dashboard ownership metadata.
+Handles pull and push of dataset, chart, and dashboard ownership metadata.
 """
 
 import logging
@@ -23,8 +23,8 @@ app = typer.Typer(help="Manage asset ownership", no_args_is_help=True)
 RESOURCE_TYPES = ["dataset", "chart", "dashboard"]
 
 
-@app.command("export")
-def export_ownership(
+@app.command("pull")
+def pull_ownership(
     path: Annotated[
         Path,
         typer.Argument(help="Output file path"),
@@ -41,21 +41,21 @@ def export_ownership(
     ] = False,
 ):
     """
-    Export asset ownership to a YAML file.
+    Pull asset ownership to a YAML file.
 
-    Exports ownership metadata for datasets, charts, and dashboards.
+    Pulls ownership metadata for datasets, charts, and dashboards.
 
     Example:
-        sup ownership export
-        sup ownership export ownership.yaml
-        sup ownership export --json
+        sup ownership pull
+        sup ownership pull ownership.yaml
+        sup ownership pull --json
     """
     from sup.clients.superset import SupSupersetClient
     from sup.config.settings import SupContext
     from sup.output.spinners import spinner
 
     try:
-        with spinner("Exporting ownership metadata", silent=porcelain):
+        with spinner("Pulling ownership metadata", silent=porcelain):
             ctx = SupContext()
             client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
 
@@ -90,7 +90,7 @@ def export_ownership(
                 yaml.dump(ownership_dict, output)
 
             console.print(
-                f"{EMOJIS['success']} Exported ownership for {total} assets to {path}",
+                f"{EMOJIS['success']} Pulled ownership for {total} assets to {path}",
                 style=RICH_STYLES["success"],
             )
 
@@ -99,14 +99,14 @@ def export_ownership(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to export ownership: {e}",
+                f"{EMOJIS['error']} Failed to pull ownership: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)
 
 
-@app.command("import")
-def import_ownership(
+@app.command("push")
+def push_ownership(
     path: Annotated[
         Path,
         typer.Argument(help="Input YAML file path"),
@@ -120,7 +120,7 @@ def import_ownership(
         typer.Option(
             "--continue-on-error",
             "-c",
-            help="Continue if an asset fails to import ownership",
+            help="Continue if an asset fails to push ownership",
         ),
     ] = False,
     dry_run: Annotated[
@@ -133,16 +133,16 @@ def import_ownership(
     ] = False,
 ):
     """
-    Import asset ownership from a YAML file.
+    Push asset ownership from a YAML file.
 
-    Reads ownership metadata from a YAML file and applies it to assets in the workspace.
+    Reads ownership metadata from a YAML file and pushes it to assets in the workspace.
     Supports checkpoint/resume via progress.log when using --continue-on-error.
 
     Example:
-        sup ownership import
-        sup ownership import ownership.yaml
-        sup ownership import --continue-on-error
-        sup ownership import --dry-run
+        sup ownership push
+        sup ownership push ownership.yaml
+        sup ownership push --continue-on-error
+        sup ownership push --dry-run
     """
     from preset_cli.cli.superset.lib import (
         LogType,
@@ -177,7 +177,7 @@ def import_ownership(
         if dry_run:
             if not porcelain:
                 console.print(
-                    f"{EMOJIS['info']} Dry run: would import ownership for {total} assets",
+                    f"{EMOJIS['info']} Dry run: would push ownership for {total} assets",
                     style=RICH_STYLES["info"],
                 )
                 for resource_name, resources in config.items():
@@ -203,10 +203,10 @@ def import_ownership(
         # Build user email->id map
         users = {user["email"]: user["id"] for user in client.client.export_users()}
 
-        imported = 0
+        pushed = 0
         failed = 0
 
-        with spinner(f"Importing ownership for {total} assets", silent=porcelain) as sp:
+        with spinner(f"Pushing ownership for {total} assets", silent=porcelain) as sp:
             with open(log_file_path, "w", encoding="utf-8") as log_file:
                 for resource_name, resources in config.items():
                     resource_ids = {
@@ -226,10 +226,10 @@ def import_ownership(
                                 users,
                                 resource_ids,
                             )
-                            imported += 1
+                            pushed += 1
                         except Exception as exc:
                             _logger.debug(
-                                "Failed to import ownership for %s %s: %s",
+                                "Failed to push ownership for %s %s: %s",
                                 resource_name,
                                 ownership["name"],
                                 str(exc),
@@ -243,7 +243,7 @@ def import_ownership(
                         write_logs_to_file(log_file, logs)
 
                         if sp:
-                            sp.text = f"Imported {imported}/{total} assets"
+                            sp.text = f"Pushed {pushed}/{total} assets"
 
         # Clean up logs on success
         if not continue_on_error or not any(
@@ -252,11 +252,11 @@ def import_ownership(
             clean_logs(LogType.OWNERSHIP, logs)
 
         if porcelain:
-            print(f"imported:{imported}")
+            print(f"pushed:{pushed}")
             if failed:
                 print(f"failed:{failed}")
         else:
-            msg = f"{EMOJIS['success']} Imported ownership for {imported} assets"
+            msg = f"{EMOJIS['success']} Pushed ownership for {pushed} assets"
             if failed:
                 msg += f" ({failed} failed)"
             console.print(msg, style=RICH_STYLES["success"])
@@ -266,7 +266,7 @@ def import_ownership(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to import ownership: {e}",
+                f"{EMOJIS['error']} Failed to push ownership: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)

--- a/src/sup/commands/ownership.py
+++ b/src/sup/commands/ownership.py
@@ -1,0 +1,274 @@
+"""
+Asset ownership management commands for sup CLI.
+
+Handles export and import of dataset, chart, and dashboard ownership metadata.
+"""
+
+import logging
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+import typer
+import yaml
+from typing_extensions import Annotated
+
+from sup.output.console import console
+from sup.output.styles import EMOJIS, RICH_STYLES
+
+_logger = logging.getLogger(__name__)
+
+app = typer.Typer(help="Manage asset ownership", no_args_is_help=True)
+
+RESOURCE_TYPES = ["dataset", "chart", "dashboard"]
+
+
+@app.command("export")
+def export_ownership(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Output file path"),
+    ] = Path("ownership.yaml"),
+    workspace_id: Annotated[
+        Optional[int],
+        typer.Option("--workspace-id", "-w", help="Override workspace"),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    yaml_output: Annotated[bool, typer.Option("--yaml", help="Output as YAML to stdout")] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Export asset ownership to a YAML file.
+
+    Exports ownership metadata for datasets, charts, and dashboards.
+
+    Example:
+        sup ownership export
+        sup ownership export ownership.yaml
+        sup ownership export --json
+    """
+    from sup.clients.superset import SupSupersetClient
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        with spinner("Exporting ownership metadata", silent=porcelain):
+            ctx = SupContext()
+            client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
+
+            ownership = defaultdict(list)
+            total = 0
+            for resource_name in RESOURCE_TYPES:
+                for resource in client.client.export_ownership(resource_name):
+                    ownership[resource_name].append(
+                        {
+                            "name": resource["name"],
+                            "uuid": str(resource["uuid"]),
+                            "owners": resource["owners"],
+                        },
+                    )
+                    total += 1
+
+        ownership_dict = dict(ownership)
+
+        if json_output:
+            import json
+
+            console.print(json.dumps(ownership_dict, indent=2))
+        elif yaml_output:
+            console.print(yaml.safe_dump(ownership_dict, default_flow_style=False))
+        elif porcelain:
+            for resource_name, resources in ownership_dict.items():
+                for res in resources:
+                    owners = ",".join(res.get("owners", []))
+                    print(f"{resource_name}\t{res['name']}\t{res['uuid']}\t{owners}")
+        else:
+            with open(path, "w", encoding="utf-8") as output:
+                yaml.dump(ownership_dict, output)
+
+            console.print(
+                f"{EMOJIS['success']} Exported ownership for {total} assets to {path}",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to export ownership: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+@app.command("import")
+def import_ownership(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Input YAML file path"),
+    ] = Path("ownership.yaml"),
+    workspace_id: Annotated[
+        Optional[int],
+        typer.Option("--workspace-id", "-w", help="Override workspace"),
+    ] = None,
+    continue_on_error: Annotated[
+        bool,
+        typer.Option(
+            "--continue-on-error",
+            "-c",
+            help="Continue if an asset fails to import ownership",
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview changes without applying"),
+    ] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Import asset ownership from a YAML file.
+
+    Reads ownership metadata from a YAML file and applies it to assets in the workspace.
+    Supports checkpoint/resume via progress.log when using --continue-on-error.
+
+    Example:
+        sup ownership import
+        sup ownership import ownership.yaml
+        sup ownership import --continue-on-error
+        sup ownership import --dry-run
+    """
+    from preset_cli.cli.superset.lib import (
+        LogType,
+        clean_logs,
+        get_logs,
+        write_logs_to_file,
+    )
+
+    from sup.clients.superset import SupSupersetClient
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        if not path.exists():
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['error']} File not found: {path}",
+                    style=RICH_STYLES["error"],
+                )
+            raise typer.Exit(1)
+
+        with open(path, encoding="utf-8") as input_:
+            config = yaml.load(input_, Loader=yaml.SafeLoader)
+
+        if not config:
+            if not porcelain:
+                console.print("No ownership data found in file.", style=RICH_STYLES["dim"])
+            return
+
+        # Count total assets
+        total = sum(len(resources) for resources in config.values())
+
+        if dry_run:
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['info']} Dry run: would import ownership for {total} assets",
+                    style=RICH_STYLES["info"],
+                )
+                for resource_name, resources in config.items():
+                    console.print(
+                        f"  {resource_name}: {len(resources)} assets",
+                        style=RICH_STYLES["dim"],
+                    )
+            else:
+                for resource_name, resources in config.items():
+                    for res in resources:
+                        print(f"import\t{resource_name}\t{res.get('name', 'unnamed')}")
+            return
+
+        ctx = SupContext()
+        client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
+
+        # Get checkpoint logs
+        log_file_path, logs = get_logs(LogType.OWNERSHIP)
+        assets_to_skip = {log["uuid"] for log in logs[LogType.OWNERSHIP]} | {
+            log["uuid"] for log in logs[LogType.ASSETS] if log["status"] == "FAILED"
+        }
+
+        # Build user email->id map
+        users = {user["email"]: user["id"] for user in client.client.export_users()}
+
+        imported = 0
+        failed = 0
+
+        with spinner(f"Importing ownership for {total} assets", silent=porcelain) as sp:
+            with open(log_file_path, "w", encoding="utf-8") as log_file:
+                for resource_name, resources in config.items():
+                    resource_ids = {
+                        str(v): k
+                        for k, v in client.client.get_uuids(resource_name).items()
+                    }
+
+                    for ownership in resources:
+                        if ownership["uuid"] in assets_to_skip:
+                            continue
+
+                        asset_log = {"uuid": ownership["uuid"], "status": "SUCCESS"}
+
+                        try:
+                            client.client.import_ownership(
+                                resource_name,
+                                ownership,
+                                users,
+                                resource_ids,
+                            )
+                            imported += 1
+                        except Exception as exc:
+                            _logger.debug(
+                                "Failed to import ownership for %s %s: %s",
+                                resource_name,
+                                ownership["name"],
+                                str(exc),
+                            )
+                            if not continue_on_error:
+                                raise
+                            asset_log["status"] = "FAILED"
+                            failed += 1
+
+                        logs[LogType.OWNERSHIP].append(asset_log)
+                        write_logs_to_file(log_file, logs)
+
+                        if sp:
+                            sp.text = f"Imported {imported}/{total} assets"
+
+        # Clean up logs on success
+        if not continue_on_error or not any(
+            log["status"] == "FAILED" for log in logs[LogType.OWNERSHIP]
+        ):
+            clean_logs(LogType.OWNERSHIP, logs)
+
+        if porcelain:
+            print(f"imported:{imported}")
+            if failed:
+                print(f"failed:{failed}")
+        else:
+            msg = f"{EMOJIS['success']} Imported ownership for {imported} assets"
+            if failed:
+                msg += f" ({failed} failed)"
+            console.print(msg, style=RICH_STYLES["success"])
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to import ownership: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)

--- a/src/sup/commands/rls.py
+++ b/src/sup/commands/rls.py
@@ -1,7 +1,7 @@
 """
 Row-Level Security (RLS) management commands for sup CLI.
 
-Handles export and import of RLS rules for Superset workspaces.
+Handles pull and push of RLS rules for Superset workspaces.
 """
 
 from pathlib import Path
@@ -17,8 +17,8 @@ from sup.output.styles import EMOJIS, RICH_STYLES
 app = typer.Typer(help="Manage row-level security rules", no_args_is_help=True)
 
 
-@app.command("export")
-def export_rls(
+@app.command("pull")
+def pull_rls(
     path: Annotated[
         Path,
         typer.Argument(help="Output file path"),
@@ -35,15 +35,15 @@ def export_rls(
     ] = False,
 ):
     """
-    Export RLS rules to a YAML file.
+    Pull RLS rules to a YAML file.
 
-    Exports all row-level security rules from the workspace to a YAML file
-    that can be version-controlled and imported into other workspaces.
+    Pulls all row-level security rules from the workspace to a YAML file
+    that can be version-controlled and pushed into other workspaces.
 
     Example:
-        sup rls export
-        sup rls export rules.yaml
-        sup rls export --json
+        sup rls pull
+        sup rls pull rules.yaml
+        sup rls pull --json
     """
     from sup.clients.superset import SupSupersetClient
     from sup.config.settings import SupContext
@@ -71,7 +71,7 @@ def export_rls(
                 yaml.dump(rules, output, sort_keys=False)
 
             console.print(
-                f"{EMOJIS['success']} Exported {len(rules)} RLS rules to {path}",
+                f"{EMOJIS['success']} Pulled {len(rules)} RLS rules to {path}",
                 style=RICH_STYLES["success"],
             )
 
@@ -80,14 +80,14 @@ def export_rls(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to export RLS rules: {e}",
+                f"{EMOJIS['error']} Failed to pull RLS rules: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)
 
 
-@app.command("import")
-def import_rls(
+@app.command("push")
+def push_rls(
     path: Annotated[
         Path,
         typer.Argument(help="Input YAML file path"),
@@ -106,15 +106,15 @@ def import_rls(
     ] = False,
 ):
     """
-    Import RLS rules from a YAML file.
+    Push RLS rules from a YAML file.
 
-    Reads RLS rules from a YAML file and imports them into the workspace.
-    Use --dry-run to preview what would be imported.
+    Reads RLS rules from a YAML file and pushes them into the workspace.
+    Use --dry-run to preview what would be pushed.
 
     Example:
-        sup rls import
-        sup rls import rules.yaml
-        sup rls import --dry-run
+        sup rls push
+        sup rls push rules.yaml
+        sup rls push --dry-run
     """
     from sup.clients.superset import SupSupersetClient
     from sup.config.settings import SupContext
@@ -140,7 +140,7 @@ def import_rls(
         if dry_run:
             if not porcelain:
                 console.print(
-                    f"{EMOJIS['info']} Dry run: would import {len(rules)} RLS rules",
+                    f"{EMOJIS['info']} Dry run: would push {len(rules)} RLS rules",
                     style=RICH_STYLES["info"],
                 )
                 for rule in rules:
@@ -154,15 +154,15 @@ def import_rls(
         ctx = SupContext()
         client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
 
-        with spinner(f"Importing {len(rules)} RLS rules", silent=porcelain):
+        with spinner(f"Pushing {len(rules)} RLS rules", silent=porcelain):
             for rule in rules:
                 client.client.import_rls(rule)
 
         if porcelain:
-            print(f"imported:{len(rules)}")
+            print(f"pushed:{len(rules)}")
         else:
             console.print(
-                f"{EMOJIS['success']} Imported {len(rules)} RLS rules from {path}",
+                f"{EMOJIS['success']} Pushed {len(rules)} RLS rules from {path}",
                 style=RICH_STYLES["success"],
             )
 
@@ -171,7 +171,7 @@ def import_rls(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to import RLS rules: {e}",
+                f"{EMOJIS['error']} Failed to push RLS rules: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)

--- a/src/sup/commands/rls.py
+++ b/src/sup/commands/rls.py
@@ -1,0 +1,177 @@
+"""
+Row-Level Security (RLS) management commands for sup CLI.
+
+Handles export and import of RLS rules for Superset workspaces.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+import yaml
+from typing_extensions import Annotated
+
+from sup.output.console import console
+from sup.output.styles import EMOJIS, RICH_STYLES
+
+app = typer.Typer(help="Manage row-level security rules", no_args_is_help=True)
+
+
+@app.command("export")
+def export_rls(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Output file path"),
+    ] = Path("rls.yaml"),
+    workspace_id: Annotated[
+        Optional[int],
+        typer.Option("--workspace-id", "-w", help="Override workspace"),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    yaml_output: Annotated[bool, typer.Option("--yaml", help="Output as YAML to stdout")] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Export RLS rules to a YAML file.
+
+    Exports all row-level security rules from the workspace to a YAML file
+    that can be version-controlled and imported into other workspaces.
+
+    Example:
+        sup rls export
+        sup rls export rules.yaml
+        sup rls export --json
+    """
+    from sup.clients.superset import SupSupersetClient
+    from sup.config.settings import SupContext
+    from sup.output.spinners import data_spinner
+
+    try:
+        with data_spinner("RLS rules", silent=porcelain):
+            ctx = SupContext()
+            client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
+            rules = list(client.client.export_rls())
+
+        if json_output:
+            import json
+
+            console.print(json.dumps(rules, indent=2))
+        elif yaml_output:
+            console.print(yaml.safe_dump(rules, default_flow_style=False, sort_keys=False))
+        elif porcelain:
+            for rule in rules:
+                name = rule.get("name", "")
+                tables = ",".join(rule.get("tables", []))
+                print(f"{name}\t{tables}")
+        else:
+            with open(path, "w", encoding="utf-8") as output:
+                yaml.dump(rules, output, sort_keys=False)
+
+            console.print(
+                f"{EMOJIS['success']} Exported {len(rules)} RLS rules to {path}",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to export RLS rules: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+@app.command("import")
+def import_rls(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Input YAML file path"),
+    ] = Path("rls.yaml"),
+    workspace_id: Annotated[
+        Optional[int],
+        typer.Option("--workspace-id", "-w", help="Override workspace"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview changes without applying"),
+    ] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Import RLS rules from a YAML file.
+
+    Reads RLS rules from a YAML file and imports them into the workspace.
+    Use --dry-run to preview what would be imported.
+
+    Example:
+        sup rls import
+        sup rls import rules.yaml
+        sup rls import --dry-run
+    """
+    from sup.clients.superset import SupSupersetClient
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        if not path.exists():
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['error']} File not found: {path}",
+                    style=RICH_STYLES["error"],
+                )
+            raise typer.Exit(1)
+
+        with open(path, encoding="utf-8") as input_:
+            rules = yaml.load(input_, Loader=yaml.SafeLoader)
+
+        if not rules:
+            if not porcelain:
+                console.print("No RLS rules found in file.", style=RICH_STYLES["dim"])
+            return
+
+        if dry_run:
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['info']} Dry run: would import {len(rules)} RLS rules",
+                    style=RICH_STYLES["info"],
+                )
+                for rule in rules:
+                    name = rule.get("name", "unnamed")
+                    console.print(f"  - {name}", style=RICH_STYLES["dim"])
+            else:
+                for rule in rules:
+                    print(f"import\t{rule.get('name', 'unnamed')}")
+            return
+
+        ctx = SupContext()
+        client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
+
+        with spinner(f"Importing {len(rules)} RLS rules", silent=porcelain):
+            for rule in rules:
+                client.client.import_rls(rule)
+
+        if porcelain:
+            print(f"imported:{len(rules)}")
+        else:
+            console.print(
+                f"{EMOJIS['success']} Imported {len(rules)} RLS rules from {path}",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to import RLS rules: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)

--- a/src/sup/commands/role.py
+++ b/src/sup/commands/role.py
@@ -6,7 +6,7 @@ Handles export, import, and sync of Superset roles and permissions.
 
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import typer
 import yaml
@@ -224,7 +224,6 @@ def sync_roles(
     """
     from preset_cli.api.clients.preset import PresetClient
     from preset_cli.cli.main import sync_all_user_roles_to_team
-
     from sup.auth.preset import get_preset_auth
     from sup.config.settings import SupContext
     from sup.output.spinners import spinner
@@ -274,9 +273,7 @@ def sync_roles(
         if not team_names:
             return
 
-        with spinner(
-            f"Syncing roles for {len(user_roles)} users", silent=porcelain
-        ) as sp:
+        with spinner(f"Syncing roles for {len(user_roles)} users", silent=porcelain) as sp:
             for team_name in team_names:
                 if sp:
                     sp.text = f"Syncing roles in team: {team_name}"
@@ -303,13 +300,13 @@ def sync_roles(
 
 
 def _resolve_teams(
-    client,
+    client: Any,
     teams: Optional[List[str]],
     porcelain: bool,
 ) -> List[str]:
     """Resolve team names from user input or prompt for selection."""
     if teams:
-        all_teams = client.get_teams()
+        all_teams: List[Dict[str, Any]] = client.get_teams()
         team_name_map = {t["title"]: t["name"] for t in all_teams}
         team_name_map.update({t["name"]: t["name"] for t in all_teams})
         resolved = []
@@ -331,9 +328,9 @@ def _resolve_teams(
 
     if not porcelain:
         console.print("\nAvailable teams:", style=RICH_STYLES["dim"])
-        for t in all_teams:
-            console.print(f"  - {t['title']} ({t['name']})")
+        for team in all_teams:
+            console.print(f"  - {team['title']} ({team['name']})")
         selected = typer.prompt("Select team name")
         return [selected]
 
-    return [t["name"] for t in all_teams]
+    return [team["name"] for team in all_teams]

--- a/src/sup/commands/role.py
+++ b/src/sup/commands/role.py
@@ -1,0 +1,339 @@
+"""
+Role management commands for sup CLI.
+
+Handles export, import, and sync of Superset roles and permissions.
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+import yaml
+from typing_extensions import Annotated
+
+from sup.output.console import console
+from sup.output.styles import EMOJIS, RICH_STYLES
+
+_logger = logging.getLogger(__name__)
+
+app = typer.Typer(help="Manage roles and permissions", no_args_is_help=True)
+
+
+@app.command("export")
+def export_roles(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Output file path"),
+    ] = Path("roles.yaml"),
+    workspace_id: Annotated[
+        Optional[int],
+        typer.Option("--workspace-id", "-w", help="Override workspace"),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    yaml_output: Annotated[bool, typer.Option("--yaml", help="Output as YAML to stdout")] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Export roles and permissions to a YAML file.
+
+    Exports all Superset roles with their permission sets from the workspace.
+
+    Example:
+        sup role export
+        sup role export roles.yaml
+        sup role export --json
+    """
+    from sup.clients.superset import SupSupersetClient
+    from sup.config.settings import SupContext
+    from sup.output.spinners import data_spinner
+
+    try:
+        with data_spinner("roles", silent=porcelain):
+            ctx = SupContext()
+            client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
+            roles = list(client.client.export_roles())
+
+        if json_output:
+            import json
+
+            console.print(json.dumps(roles, indent=2))
+        elif yaml_output:
+            console.print(yaml.safe_dump(roles, default_flow_style=False))
+        elif porcelain:
+            for role in roles:
+                name = role.get("name", "")
+                perm_count = len(role.get("permissions", []))
+                print(f"{name}\t{perm_count}")
+        else:
+            with open(path, "w", encoding="utf-8") as output:
+                yaml.dump(roles, output)
+
+            console.print(
+                f"{EMOJIS['success']} Exported {len(roles)} roles to {path}",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to export roles: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+@app.command("import")
+def import_roles(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Input YAML file path"),
+    ] = Path("roles.yaml"),
+    workspace_id: Annotated[
+        Optional[int],
+        typer.Option("--workspace-id", "-w", help="Override workspace"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview changes without applying"),
+    ] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Import roles and permissions from a YAML file.
+
+    Reads roles from a YAML file and imports them into the workspace.
+
+    Example:
+        sup role import
+        sup role import roles.yaml
+        sup role import --dry-run
+    """
+    from sup.clients.superset import SupSupersetClient
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        if not path.exists():
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['error']} File not found: {path}",
+                    style=RICH_STYLES["error"],
+                )
+            raise typer.Exit(1)
+
+        with open(path, encoding="utf-8") as input_:
+            roles = yaml.load(input_, Loader=yaml.SafeLoader)
+
+        if not roles:
+            if not porcelain:
+                console.print("No roles found in file.", style=RICH_STYLES["dim"])
+            return
+
+        if dry_run:
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['info']} Dry run: would import {len(roles)} roles",
+                    style=RICH_STYLES["info"],
+                )
+                for role in roles:
+                    name = role.get("name", "unnamed")
+                    perm_count = len(role.get("permissions", []))
+                    console.print(
+                        f"  - {name} ({perm_count} permissions)",
+                        style=RICH_STYLES["dim"],
+                    )
+            else:
+                for role in roles:
+                    print(f"import\t{role.get('name', 'unnamed')}")
+            return
+
+        ctx = SupContext()
+        client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
+
+        with spinner(f"Importing {len(roles)} roles", silent=porcelain):
+            for role in roles:
+                client.client.import_role(role)
+
+        if porcelain:
+            print(f"imported:{len(roles)}")
+        else:
+            console.print(
+                f"{EMOJIS['success']} Imported {len(roles)} roles from {path}",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to import roles: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+@app.command("sync")
+def sync_roles(
+    path: Annotated[
+        Path,
+        typer.Argument(help="YAML file with user role definitions"),
+    ] = Path("user_roles.yaml"),
+    teams: Annotated[
+        Optional[List[str]],
+        typer.Option("--team", "-t", help="Target team (repeatable)"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview changes without applying"),
+    ] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Sync team, workspace, and data access roles from a YAML file.
+
+    Reads a YAML file defining user roles across teams and workspaces,
+    and applies the role assignments. Handles team roles, workspace roles,
+    and Superset data access roles.
+
+    YAML format:
+        - email: user@example.com
+          team_role: admin
+          workspaces:
+            Workspace Title:
+              workspace_role: primary creator
+              data_access_roles:
+                - "Role Name"
+
+    Example:
+        sup role sync user_roles.yaml
+        sup role sync user_roles.yaml --team "My Team"
+        sup role sync --dry-run
+    """
+    from preset_cli.api.clients.preset import PresetClient
+    from preset_cli.cli.main import sync_all_user_roles_to_team
+
+    from sup.auth.preset import get_preset_auth
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        if not path.exists():
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['error']} File not found: {path}",
+                    style=RICH_STYLES["error"],
+                )
+            raise typer.Exit(1)
+
+        with open(path, encoding="utf-8") as input_:
+            user_roles = yaml.load(input_, Loader=yaml.SafeLoader)
+
+        if not user_roles:
+            if not porcelain:
+                console.print("No role definitions found in file.", style=RICH_STYLES["dim"])
+            return
+
+        if dry_run:
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['info']} Dry run: would sync roles for {len(user_roles)} users",
+                    style=RICH_STYLES["info"],
+                )
+                for user in user_roles:
+                    email = user.get("email", "unknown")
+                    team_role = user.get("team_role", "unknown")
+                    ws_count = len(user.get("workspaces", {}))
+                    console.print(
+                        f"  - {email} (team: {team_role}, {ws_count} workspaces)",
+                        style=RICH_STYLES["dim"],
+                    )
+            else:
+                for user in user_roles:
+                    print(f"sync\t{user.get('email', 'unknown')}")
+            return
+
+        ctx = SupContext()
+        auth = get_preset_auth(ctx)
+        client = PresetClient("https://api.app.preset.io/", auth)
+
+        # Resolve teams
+        team_names = _resolve_teams(client, teams, porcelain)
+        if not team_names:
+            return
+
+        with spinner(
+            f"Syncing roles for {len(user_roles)} users", silent=porcelain
+        ) as sp:
+            for team_name in team_names:
+                if sp:
+                    sp.text = f"Syncing roles in team: {team_name}"
+                workspaces = client.get_workspaces(team_name)
+                sync_all_user_roles_to_team(client, team_name, user_roles, workspaces)
+
+        if porcelain:
+            print(f"synced:{len(user_roles)}")
+        else:
+            console.print(
+                f"{EMOJIS['success']} Synced roles for {len(user_roles)} users",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to sync roles: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+def _resolve_teams(
+    client,
+    teams: Optional[List[str]],
+    porcelain: bool,
+) -> List[str]:
+    """Resolve team names from user input or prompt for selection."""
+    if teams:
+        all_teams = client.get_teams()
+        team_name_map = {t["title"]: t["name"] for t in all_teams}
+        team_name_map.update({t["name"]: t["name"] for t in all_teams})
+        resolved = []
+        for t in teams:
+            if t in team_name_map:
+                resolved.append(team_name_map[t])
+            else:
+                _logger.warning("Team '%s' not found, skipping", t)
+        return resolved
+
+    all_teams = client.get_teams()
+    if not all_teams:
+        if not porcelain:
+            console.print("No teams found.", style=RICH_STYLES["dim"])
+        return []
+
+    if len(all_teams) == 1:
+        return [all_teams[0]["name"]]
+
+    if not porcelain:
+        console.print("\nAvailable teams:", style=RICH_STYLES["dim"])
+        for t in all_teams:
+            console.print(f"  - {t['title']} ({t['name']})")
+        selected = typer.prompt("Select team name")
+        return [selected]
+
+    return [t["name"] for t in all_teams]

--- a/src/sup/commands/role.py
+++ b/src/sup/commands/role.py
@@ -1,7 +1,7 @@
 """
 Role management commands for sup CLI.
 
-Handles export, import, and sync of Superset roles and permissions.
+Handles pull, push, and sync of Superset roles and permissions.
 """
 
 import logging
@@ -20,8 +20,8 @@ _logger = logging.getLogger(__name__)
 app = typer.Typer(help="Manage roles and permissions", no_args_is_help=True)
 
 
-@app.command("export")
-def export_roles(
+@app.command("pull")
+def pull_roles(
     path: Annotated[
         Path,
         typer.Argument(help="Output file path"),
@@ -38,14 +38,14 @@ def export_roles(
     ] = False,
 ):
     """
-    Export roles and permissions to a YAML file.
+    Pull roles and permissions to a YAML file.
 
-    Exports all Superset roles with their permission sets from the workspace.
+    Pulls all Superset roles with their permission sets from the workspace.
 
     Example:
-        sup role export
-        sup role export roles.yaml
-        sup role export --json
+        sup role pull
+        sup role pull roles.yaml
+        sup role pull --json
     """
     from sup.clients.superset import SupSupersetClient
     from sup.config.settings import SupContext
@@ -73,7 +73,7 @@ def export_roles(
                 yaml.dump(roles, output)
 
             console.print(
-                f"{EMOJIS['success']} Exported {len(roles)} roles to {path}",
+                f"{EMOJIS['success']} Pulled {len(roles)} roles to {path}",
                 style=RICH_STYLES["success"],
             )
 
@@ -82,14 +82,14 @@ def export_roles(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to export roles: {e}",
+                f"{EMOJIS['error']} Failed to pull roles: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)
 
 
-@app.command("import")
-def import_roles(
+@app.command("push")
+def push_roles(
     path: Annotated[
         Path,
         typer.Argument(help="Input YAML file path"),
@@ -108,14 +108,14 @@ def import_roles(
     ] = False,
 ):
     """
-    Import roles and permissions from a YAML file.
+    Push roles and permissions from a YAML file.
 
-    Reads roles from a YAML file and imports them into the workspace.
+    Reads roles from a YAML file and pushes them into the workspace.
 
     Example:
-        sup role import
-        sup role import roles.yaml
-        sup role import --dry-run
+        sup role push
+        sup role push roles.yaml
+        sup role push --dry-run
     """
     from sup.clients.superset import SupSupersetClient
     from sup.config.settings import SupContext
@@ -141,7 +141,7 @@ def import_roles(
         if dry_run:
             if not porcelain:
                 console.print(
-                    f"{EMOJIS['info']} Dry run: would import {len(roles)} roles",
+                    f"{EMOJIS['info']} Dry run: would push {len(roles)} roles",
                     style=RICH_STYLES["info"],
                 )
                 for role in roles:
@@ -159,15 +159,15 @@ def import_roles(
         ctx = SupContext()
         client = SupSupersetClient.from_context(ctx, workspace_id=workspace_id)
 
-        with spinner(f"Importing {len(roles)} roles", silent=porcelain):
+        with spinner(f"Pushing {len(roles)} roles", silent=porcelain):
             for role in roles:
                 client.client.import_role(role)
 
         if porcelain:
-            print(f"imported:{len(roles)}")
+            print(f"pushed:{len(roles)}")
         else:
             console.print(
-                f"{EMOJIS['success']} Imported {len(roles)} roles from {path}",
+                f"{EMOJIS['success']} Pushed {len(roles)} roles from {path}",
                 style=RICH_STYLES["success"],
             )
 
@@ -176,7 +176,7 @@ def import_roles(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to import roles: {e}",
+                f"{EMOJIS['error']} Failed to push roles: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)

--- a/src/sup/main.py
+++ b/src/sup/main.py
@@ -152,8 +152,18 @@ app.add_typer(
 app.add_typer(query.app, name="query", help="Manage saved queries", rich_help_panel="Manage Assets")
 app.add_typer(user.app, name="user", help="Manage users", rich_help_panel="Manage Assets")
 app.add_typer(group.app, name="group", help="Manage SCIM groups", rich_help_panel="Manage Assets")
-app.add_typer(rls.app, name="rls", help="Manage row-level security", rich_help_panel="Security & Governance")
-app.add_typer(role.app, name="role", help="Manage roles and permissions", rich_help_panel="Security & Governance")
+app.add_typer(
+    rls.app,
+    name="rls",
+    help="Manage row-level security",
+    rich_help_panel="Security & Governance",
+)
+app.add_typer(
+    role.app,
+    name="role",
+    help="Manage roles and permissions",
+    rich_help_panel="Security & Governance",
+)
 app.add_typer(
     ownership.app,
     name="ownership",

--- a/src/sup/main.py
+++ b/src/sup/main.py
@@ -16,7 +16,10 @@ from sup.commands import (
     dataset,
     dbt,
     group,
+    ownership,
     query,
+    rls,
+    role,
     sql,
     sync,
     theme,
@@ -149,6 +152,14 @@ app.add_typer(
 app.add_typer(query.app, name="query", help="Manage saved queries", rich_help_panel="Manage Assets")
 app.add_typer(user.app, name="user", help="Manage users", rich_help_panel="Manage Assets")
 app.add_typer(group.app, name="group", help="Manage SCIM groups", rich_help_panel="Manage Assets")
+app.add_typer(rls.app, name="rls", help="Manage row-level security", rich_help_panel="Security & Governance")
+app.add_typer(role.app, name="role", help="Manage roles and permissions", rich_help_panel="Security & Governance")
+app.add_typer(
+    ownership.app,
+    name="ownership",
+    help="Manage asset ownership",
+    rich_help_panel="Security & Governance",
+)
 app.add_typer(sync.app, name="sync", rich_help_panel="Synchronize Assets Across Workspaces")
 app.add_typer(dbt.app, name="dbt", rich_help_panel="Integrations & Metadata")
 app.add_typer(theme.app, name="theme", help="Test themes and colors", hidden=True)

--- a/tests/sup/commands/test_ownership.py
+++ b/tests/sup/commands/test_ownership.py
@@ -1,0 +1,143 @@
+"""
+Tests for the sup ownership export/import commands.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import yaml
+from typer.testing import CliRunner
+
+from sup.commands.ownership import app
+
+runner = CliRunner()
+
+SAMPLE_OWNERSHIP = {
+    "dataset": [
+        {
+            "name": "test_table",
+            "uuid": "e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0",
+            "owners": ["admin@example.com"],
+        },
+    ],
+    "chart": [
+        {
+            "name": "test_chart",
+            "uuid": "f5f7b25c-d4f9-5eef-b961-294cb7df26f1",
+            "owners": ["admin@example.com", "user@example.com"],
+        },
+    ],
+}
+
+PATCH_CLIENT = "sup.clients.superset.SupSupersetClient"
+PATCH_CONTEXT = "sup.config.settings.SupContext"
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_ownership(_MockContext, MockClient):
+    """Test exporting ownership to a YAML file."""
+    mock_client = MagicMock()
+
+    def mock_export_ownership(resource_name):
+        data = {
+            "dataset": [
+                {
+                    "name": "test_table",
+                    "uuid": UUID("e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0"),
+                    "owners": ["admin@example.com"],
+                }
+            ],
+            "chart": [
+                {
+                    "name": "test_chart",
+                    "uuid": UUID("f5f7b25c-d4f9-5eef-b961-294cb7df26f1"),
+                    "owners": ["admin@example.com", "user@example.com"],
+                }
+            ],
+            "dashboard": [],
+        }
+        return iter(data.get(resource_name, []))
+
+    mock_client.client.export_ownership.side_effect = mock_export_ownership
+    MockClient.from_context.return_value = mock_client
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["export", "ownership.yaml"])
+        assert result.exit_code == 0
+
+        with open("ownership.yaml") as f:
+            exported = yaml.safe_load(f)
+        assert "dataset" in exported
+        assert "chart" in exported
+        assert len(exported["dataset"]) == 1
+        assert exported["dataset"][0]["name"] == "test_table"
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_ownership_json(_MockContext, MockClient):
+    """Test exporting ownership as JSON."""
+    mock_client = MagicMock()
+    mock_client.client.export_ownership.return_value = iter([])
+    MockClient.from_context.return_value = mock_client
+
+    result = runner.invoke(app, ["export", "--json"])
+    assert result.exit_code == 0
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership(
+    _MockContext, MockClient, mock_get_logs, _mock_write_logs, _mock_clean_logs
+):
+    """Test importing ownership from a YAML file."""
+    from preset_cli.cli.superset.lib import LogType
+
+    mock_client = MagicMock()
+    mock_client.client.export_users.return_value = [
+        {"id": 1, "email": "admin@example.com"},
+    ]
+    mock_client.client.get_uuids.return_value = {
+        1: UUID("e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0"),
+    }
+    MockClient.from_context.return_value = mock_client
+
+    mock_get_logs.return_value = (
+        "progress.log",
+        {LogType.OWNERSHIP: [], LogType.ASSETS: []},
+    )
+
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+
+        # Create the progress.log file that get_logs returns
+        with open("progress.log", "w") as f:
+            pass
+
+        result = runner.invoke(app, ["import", "ownership.yaml"])
+        assert result.exit_code == 0
+
+    assert mock_client.client.import_ownership.call_count == 2
+
+
+def test_import_ownership_dry_run():
+    """Test importing ownership with --dry-run."""
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+
+        result = runner.invoke(app, ["import", "ownership.yaml", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run" in result.output
+
+
+def test_import_ownership_file_not_found():
+    """Test importing from non-existent file."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["import", "nonexistent.yaml"])
+        assert result.exit_code == 1

--- a/tests/sup/commands/test_ownership.py
+++ b/tests/sup/commands/test_ownership.py
@@ -1,4 +1,4 @@
-"""Tests for the sup ownership export/import commands."""
+"""Tests for the sup ownership pull/push commands."""
 
 from unittest.mock import MagicMock, patch
 from uuid import UUID
@@ -52,52 +52,52 @@ def _mock_export_ownership(resource_name):
     return iter(data.get(resource_name, []))
 
 
-# --- Export tests ---
+# --- Pull tests ---
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_ownership(_MockContext, MockClient):
+def test_pull_ownership(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_ownership.side_effect = _mock_export_ownership
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["export", "ownership.yaml"])
+        result = runner.invoke(app, ["pull", "ownership.yaml"])
         assert result.exit_code == 0
         with open("ownership.yaml") as f:
-            exported = yaml.safe_load(f)
-        assert "dataset" in exported
-        assert "chart" in exported
+            pulled = yaml.safe_load(f)
+        assert "dataset" in pulled
+        assert "chart" in pulled
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_ownership_json(_MockContext, MockClient):
+def test_pull_ownership_json(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_ownership.return_value = iter([])
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--json"])
+    result = runner.invoke(app, ["pull", "--json"])
     assert result.exit_code == 0
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_ownership_yaml(_MockContext, MockClient):
+def test_pull_ownership_yaml(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_ownership.side_effect = _mock_export_ownership
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--yaml"])
+    result = runner.invoke(app, ["pull", "--yaml"])
     assert result.exit_code == 0
     assert "test_table" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_ownership_porcelain(_MockContext, MockClient):
+def test_pull_ownership_porcelain(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_ownership.side_effect = _mock_export_ownership
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--porcelain"])
+    result = runner.invoke(app, ["pull", "--porcelain"])
     assert result.exit_code == 0
     assert "dataset\ttest_table\t" in result.output
     assert "chart\ttest_chart\t" in result.output
@@ -105,26 +105,26 @@ def test_export_ownership_porcelain(_MockContext, MockClient):
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_ownership_error(_MockContext, MockClient):
+def test_pull_ownership_error(_MockContext, MockClient):
     MockClient.from_context.side_effect = RuntimeError("boom")
-    result = runner.invoke(app, ["export"])
+    result = runner.invoke(app, ["pull"])
     assert result.exit_code == 1
-    assert "Failed to export ownership" in result.output
+    assert "Failed to pull ownership" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_ownership_error_porcelain(_MockContext, MockClient):
+def test_pull_ownership_error_porcelain(_MockContext, MockClient):
     MockClient.from_context.side_effect = RuntimeError("boom")
-    result = runner.invoke(app, ["export", "--porcelain"])
+    result = runner.invoke(app, ["pull", "--porcelain"])
     assert result.exit_code == 1
     assert "Failed" not in result.output
 
 
-# --- Import tests ---
+# --- Push tests ---
 
 
-def _setup_import_mocks(MockClient, mock_get_logs, import_side_effect=None):
+def _setup_push_mocks(MockClient, mock_get_logs, import_side_effect=None):
     from preset_cli.cli.superset.lib import LogType
 
     mock_client = MagicMock()
@@ -149,14 +149,14 @@ def _setup_import_mocks(MockClient, mock_get_logs, import_side_effect=None):
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership(_MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean):
-    _setup_import_mocks(MockClient, mock_get_logs)
+def test_push_ownership(_MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean):
+    _setup_push_mocks(MockClient, mock_get_logs)
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
         with open("progress.log", "w") as f:
             pass
-        result = runner.invoke(app, ["import", "ownership.yaml"])
+        result = runner.invoke(app, ["push", "ownership.yaml"])
         assert result.exit_code == 0
     mock = MockClient.from_context.return_value
     assert mock.client.import_ownership.call_count == 2
@@ -167,18 +167,18 @@ def test_import_ownership(_MockContext, MockClient, mock_get_logs, _mock_write, 
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_porcelain(
+def test_push_ownership_porcelain(
     _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
 ):
-    _setup_import_mocks(MockClient, mock_get_logs)
+    _setup_push_mocks(MockClient, mock_get_logs)
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
         with open("progress.log", "w") as f:
             pass
-        result = runner.invoke(app, ["import", "ownership.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "ownership.yaml", "--porcelain"])
         assert result.exit_code == 0
-        assert "imported:2" in result.output
+        assert "pushed:2" in result.output
 
 
 @patch("preset_cli.cli.superset.lib.clean_logs")
@@ -186,7 +186,7 @@ def test_import_ownership_porcelain(
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_skip_checkpoint(
+def test_push_ownership_skip_checkpoint(
     _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
 ):
     from preset_cli.cli.superset.lib import LogType
@@ -213,7 +213,7 @@ def test_import_ownership_skip_checkpoint(
             yaml.dump(SAMPLE_OWNERSHIP, f)
         with open("progress.log", "w") as f:
             pass
-        result = runner.invoke(app, ["import", "ownership.yaml"])
+        result = runner.invoke(app, ["push", "ownership.yaml"])
         assert result.exit_code == 0
     assert mock_client.client.import_ownership.call_count == 1
 
@@ -223,10 +223,10 @@ def test_import_ownership_skip_checkpoint(
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_continue_on_error(
+def test_push_ownership_continue_on_error(
     _MockContext, MockClient, mock_get_logs, _mock_write, mock_clean
 ):
-    _setup_import_mocks(
+    _setup_push_mocks(
         MockClient,
         mock_get_logs,
         import_side_effect=[None, RuntimeError("permission denied")],
@@ -236,7 +236,7 @@ def test_import_ownership_continue_on_error(
             yaml.dump(SAMPLE_OWNERSHIP, f)
         with open("progress.log", "w") as f:
             pass
-        result = runner.invoke(app, ["import", "ownership.yaml", "--continue-on-error"])
+        result = runner.invoke(app, ["push", "ownership.yaml", "--continue-on-error"])
         assert result.exit_code == 0
         assert "1 failed" in result.output
     mock_clean.assert_not_called()
@@ -247,10 +247,10 @@ def test_import_ownership_continue_on_error(
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_continue_on_error_porcelain(
+def test_push_ownership_continue_on_error_porcelain(
     _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
 ):
-    _setup_import_mocks(
+    _setup_push_mocks(
         MockClient,
         mock_get_logs,
         import_side_effect=[None, RuntimeError("permission denied")],
@@ -262,10 +262,10 @@ def test_import_ownership_continue_on_error_porcelain(
             pass
         result = runner.invoke(
             app,
-            ["import", "ownership.yaml", "--continue-on-error", "--porcelain"],
+            ["push", "ownership.yaml", "--continue-on-error", "--porcelain"],
         )
         assert result.exit_code == 0
-        assert "imported:1" in result.output
+        assert "pushed:1" in result.output
         assert "failed:1" in result.output
 
 
@@ -274,10 +274,10 @@ def test_import_ownership_continue_on_error_porcelain(
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_error_no_continue(
+def test_push_ownership_error_no_continue(
     _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
 ):
-    _setup_import_mocks(
+    _setup_push_mocks(
         MockClient,
         mock_get_logs,
         import_side_effect=RuntimeError("server error"),
@@ -287,9 +287,9 @@ def test_import_ownership_error_no_continue(
             yaml.dump(SAMPLE_OWNERSHIP, f)
         with open("progress.log", "w") as f:
             pass
-        result = runner.invoke(app, ["import", "ownership.yaml"])
+        result = runner.invoke(app, ["push", "ownership.yaml"])
         assert result.exit_code == 1
-        assert "Failed to import ownership" in result.output
+        assert "Failed to push ownership" in result.output
 
 
 @patch("preset_cli.cli.superset.lib.clean_logs")
@@ -297,10 +297,10 @@ def test_import_ownership_error_no_continue(
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_error_porcelain(
+def test_push_ownership_error_porcelain(
     _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
 ):
-    _setup_import_mocks(
+    _setup_push_mocks(
         MockClient,
         mock_get_logs,
         import_side_effect=RuntimeError("server error"),
@@ -310,68 +310,68 @@ def test_import_ownership_error_porcelain(
             yaml.dump(SAMPLE_OWNERSHIP, f)
         with open("progress.log", "w") as f:
             pass
-        result = runner.invoke(app, ["import", "ownership.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "ownership.yaml", "--porcelain"])
         assert result.exit_code == 1
         assert "Failed" not in result.output
 
 
-def test_import_ownership_dry_run():
+def test_push_ownership_dry_run():
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
-        result = runner.invoke(app, ["import", "ownership.yaml", "--dry-run"])
+        result = runner.invoke(app, ["push", "ownership.yaml", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output
 
 
-def test_import_ownership_dry_run_porcelain():
+def test_push_ownership_dry_run_porcelain():
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
-        result = runner.invoke(app, ["import", "ownership.yaml", "--dry-run", "--porcelain"])
+        result = runner.invoke(app, ["push", "ownership.yaml", "--dry-run", "--porcelain"])
         assert result.exit_code == 0
         assert "import\tdataset\ttest_table" in result.output
         assert "import\tchart\ttest_chart" in result.output
 
 
-def test_import_ownership_file_not_found():
+def test_push_ownership_file_not_found():
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["import", "nonexistent.yaml"])
+        result = runner.invoke(app, ["push", "nonexistent.yaml"])
         assert result.exit_code == 1
 
 
-def test_import_ownership_file_not_found_porcelain():
+def test_push_ownership_file_not_found_porcelain():
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["import", "nonexistent.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "nonexistent.yaml", "--porcelain"])
         assert result.exit_code == 1
         assert "File not found" not in result.output
 
 
-def test_import_ownership_empty_file():
+def test_push_ownership_empty_file():
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             f.write("")
-        result = runner.invoke(app, ["import", "ownership.yaml"])
+        result = runner.invoke(app, ["push", "ownership.yaml"])
         assert result.exit_code == 0
         assert "No ownership data" in result.output
 
 
-def test_import_ownership_empty_file_porcelain():
+def test_push_ownership_empty_file_porcelain():
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             f.write("")
-        result = runner.invoke(app, ["import", "ownership.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "ownership.yaml", "--porcelain"])
         assert result.exit_code == 0
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_ownership_typer_exit(_MockContext, MockClient):
-    """Cover except typer.Exit: raise in export."""
+def test_pull_ownership_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in pull."""
     import typer
 
     MockClient.from_context.side_effect = typer.Exit(1)
-    result = runner.invoke(app, ["export"])
+    result = runner.invoke(app, ["pull"])
     assert result.exit_code == 1
 
 
@@ -380,17 +380,17 @@ def test_export_ownership_typer_exit(_MockContext, MockClient):
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_typer_exit(
+def test_push_ownership_typer_exit(
     _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
 ):
-    """Cover except typer.Exit: raise in import."""
+    """Cover except typer.Exit: raise in push."""
     import typer
 
     MockClient.from_context.side_effect = typer.Exit(1)
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
-        result = runner.invoke(app, ["import", "ownership.yaml"])
+        result = runner.invoke(app, ["push", "ownership.yaml"])
         assert result.exit_code == 1
 
 
@@ -399,16 +399,16 @@ def test_import_ownership_typer_exit(
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership_continue_on_error_all_success(
+def test_push_ownership_continue_on_error_all_success(
     _MockContext, MockClient, mock_get_logs, _mock_write, mock_clean
 ):
     """Cover clean_logs path when continue_on_error=True and all succeed."""
-    _setup_import_mocks(MockClient, mock_get_logs)
+    _setup_push_mocks(MockClient, mock_get_logs)
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
         with open("progress.log", "w") as f:
             pass
-        result = runner.invoke(app, ["import", "ownership.yaml", "--continue-on-error"])
+        result = runner.invoke(app, ["push", "ownership.yaml", "--continue-on-error"])
         assert result.exit_code == 0
     mock_clean.assert_called_once()

--- a/tests/sup/commands/test_ownership.py
+++ b/tests/sup/commands/test_ownership.py
@@ -1,6 +1,4 @@
-"""
-Tests for the sup ownership export/import commands.
-"""
+"""Tests for the sup ownership export/import commands."""
 
 from unittest.mock import MagicMock, patch
 from uuid import UUID
@@ -33,57 +31,117 @@ PATCH_CLIENT = "sup.clients.superset.SupSupersetClient"
 PATCH_CONTEXT = "sup.config.settings.SupContext"
 
 
+def _mock_export_ownership(resource_name):
+    data = {
+        "dataset": [
+            {
+                "name": "test_table",
+                "uuid": UUID("e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0"),
+                "owners": ["admin@example.com"],
+            }
+        ],
+        "chart": [
+            {
+                "name": "test_chart",
+                "uuid": UUID("f5f7b25c-d4f9-5eef-b961-294cb7df26f1"),
+                "owners": ["admin@example.com", "user@example.com"],
+            }
+        ],
+        "dashboard": [],
+    }
+    return iter(data.get(resource_name, []))
+
+
+# --- Export tests ---
+
+
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
 def test_export_ownership(_MockContext, MockClient):
-    """Test exporting ownership to a YAML file."""
     mock_client = MagicMock()
-
-    def mock_export_ownership(resource_name):
-        data = {
-            "dataset": [
-                {
-                    "name": "test_table",
-                    "uuid": UUID("e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0"),
-                    "owners": ["admin@example.com"],
-                }
-            ],
-            "chart": [
-                {
-                    "name": "test_chart",
-                    "uuid": UUID("f5f7b25c-d4f9-5eef-b961-294cb7df26f1"),
-                    "owners": ["admin@example.com", "user@example.com"],
-                }
-            ],
-            "dashboard": [],
-        }
-        return iter(data.get(resource_name, []))
-
-    mock_client.client.export_ownership.side_effect = mock_export_ownership
+    mock_client.client.export_ownership.side_effect = _mock_export_ownership
     MockClient.from_context.return_value = mock_client
-
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["export", "ownership.yaml"])
         assert result.exit_code == 0
-
         with open("ownership.yaml") as f:
             exported = yaml.safe_load(f)
         assert "dataset" in exported
         assert "chart" in exported
-        assert len(exported["dataset"]) == 1
-        assert exported["dataset"][0]["name"] == "test_table"
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
 def test_export_ownership_json(_MockContext, MockClient):
-    """Test exporting ownership as JSON."""
     mock_client = MagicMock()
     mock_client.client.export_ownership.return_value = iter([])
     MockClient.from_context.return_value = mock_client
-
     result = runner.invoke(app, ["export", "--json"])
     assert result.exit_code == 0
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_ownership_yaml(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.export_ownership.side_effect = _mock_export_ownership
+    MockClient.from_context.return_value = mock_client
+    result = runner.invoke(app, ["export", "--yaml"])
+    assert result.exit_code == 0
+    assert "test_table" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_ownership_porcelain(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.export_ownership.side_effect = _mock_export_ownership
+    MockClient.from_context.return_value = mock_client
+    result = runner.invoke(app, ["export", "--porcelain"])
+    assert result.exit_code == 0
+    assert "dataset\ttest_table\t" in result.output
+    assert "chart\ttest_chart\t" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_ownership_error(_MockContext, MockClient):
+    MockClient.from_context.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["export"])
+    assert result.exit_code == 1
+    assert "Failed to export ownership" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_ownership_error_porcelain(_MockContext, MockClient):
+    MockClient.from_context.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["export", "--porcelain"])
+    assert result.exit_code == 1
+    assert "Failed" not in result.output
+
+
+# --- Import tests ---
+
+
+def _setup_import_mocks(MockClient, mock_get_logs, import_side_effect=None):
+    from preset_cli.cli.superset.lib import LogType
+
+    mock_client = MagicMock()
+    mock_client.client.export_users.return_value = [
+        {"id": 1, "email": "admin@example.com"},
+    ]
+    mock_client.client.get_uuids.return_value = {
+        1: UUID("e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0"),
+    }
+    if import_side_effect:
+        mock_client.client.import_ownership.side_effect = import_side_effect
+    MockClient.from_context.return_value = mock_client
+    mock_get_logs.return_value = (
+        "progress.log",
+        {LogType.OWNERSHIP: [], LogType.ASSETS: []},
+    )
+    return mock_client
 
 
 @patch("preset_cli.cli.superset.lib.clean_logs")
@@ -91,10 +149,46 @@ def test_export_ownership_json(_MockContext, MockClient):
 @patch("preset_cli.cli.superset.lib.get_logs")
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_ownership(
-    _MockContext, MockClient, mock_get_logs, _mock_write_logs, _mock_clean_logs
+def test_import_ownership(_MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean):
+    _setup_import_mocks(MockClient, mock_get_logs)
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        with open("progress.log", "w") as f:
+            pass
+        result = runner.invoke(app, ["import", "ownership.yaml"])
+        assert result.exit_code == 0
+    mock = MockClient.from_context.return_value
+    assert mock.client.import_ownership.call_count == 2
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_porcelain(
+    _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
 ):
-    """Test importing ownership from a YAML file."""
+    _setup_import_mocks(MockClient, mock_get_logs)
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        with open("progress.log", "w") as f:
+            pass
+        result = runner.invoke(app, ["import", "ownership.yaml", "--porcelain"])
+        assert result.exit_code == 0
+        assert "imported:2" in result.output
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_skip_checkpoint(
+    _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
+):
     from preset_cli.cli.superset.lib import LogType
 
     mock_client = MagicMock()
@@ -105,39 +199,216 @@ def test_import_ownership(
         1: UUID("e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0"),
     }
     MockClient.from_context.return_value = mock_client
-
     mock_get_logs.return_value = (
         "progress.log",
-        {LogType.OWNERSHIP: [], LogType.ASSETS: []},
+        {
+            LogType.OWNERSHIP: [
+                {"uuid": "e4e6a14b-c3e8-4fdf-a850-183ba6ce15e0", "status": "SUCCESS"}
+            ],
+            LogType.ASSETS: [],
+        },
     )
-
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
-
-        # Create the progress.log file that get_logs returns
         with open("progress.log", "w") as f:
             pass
-
         result = runner.invoke(app, ["import", "ownership.yaml"])
         assert result.exit_code == 0
+    assert mock_client.client.import_ownership.call_count == 1
 
-    assert mock_client.client.import_ownership.call_count == 2
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_continue_on_error(
+    _MockContext, MockClient, mock_get_logs, _mock_write, mock_clean
+):
+    _setup_import_mocks(
+        MockClient,
+        mock_get_logs,
+        import_side_effect=[None, RuntimeError("permission denied")],
+    )
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        with open("progress.log", "w") as f:
+            pass
+        result = runner.invoke(app, ["import", "ownership.yaml", "--continue-on-error"])
+        assert result.exit_code == 0
+        assert "1 failed" in result.output
+    mock_clean.assert_not_called()
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_continue_on_error_porcelain(
+    _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
+):
+    _setup_import_mocks(
+        MockClient,
+        mock_get_logs,
+        import_side_effect=[None, RuntimeError("permission denied")],
+    )
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        with open("progress.log", "w") as f:
+            pass
+        result = runner.invoke(
+            app,
+            ["import", "ownership.yaml", "--continue-on-error", "--porcelain"],
+        )
+        assert result.exit_code == 0
+        assert "imported:1" in result.output
+        assert "failed:1" in result.output
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_error_no_continue(
+    _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
+):
+    _setup_import_mocks(
+        MockClient,
+        mock_get_logs,
+        import_side_effect=RuntimeError("server error"),
+    )
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        with open("progress.log", "w") as f:
+            pass
+        result = runner.invoke(app, ["import", "ownership.yaml"])
+        assert result.exit_code == 1
+        assert "Failed to import ownership" in result.output
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_error_porcelain(
+    _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
+):
+    _setup_import_mocks(
+        MockClient,
+        mock_get_logs,
+        import_side_effect=RuntimeError("server error"),
+    )
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        with open("progress.log", "w") as f:
+            pass
+        result = runner.invoke(app, ["import", "ownership.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "Failed" not in result.output
 
 
 def test_import_ownership_dry_run():
-    """Test importing ownership with --dry-run."""
     with runner.isolated_filesystem():
         with open("ownership.yaml", "w") as f:
             yaml.dump(SAMPLE_OWNERSHIP, f)
-
         result = runner.invoke(app, ["import", "ownership.yaml", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output
 
 
+def test_import_ownership_dry_run_porcelain():
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        result = runner.invoke(app, ["import", "ownership.yaml", "--dry-run", "--porcelain"])
+        assert result.exit_code == 0
+        assert "import\tdataset\ttest_table" in result.output
+        assert "import\tchart\ttest_chart" in result.output
+
+
 def test_import_ownership_file_not_found():
-    """Test importing from non-existent file."""
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["import", "nonexistent.yaml"])
         assert result.exit_code == 1
+
+
+def test_import_ownership_file_not_found_porcelain():
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["import", "nonexistent.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "File not found" not in result.output
+
+
+def test_import_ownership_empty_file():
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["import", "ownership.yaml"])
+        assert result.exit_code == 0
+        assert "No ownership data" in result.output
+
+
+def test_import_ownership_empty_file_porcelain():
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["import", "ownership.yaml", "--porcelain"])
+        assert result.exit_code == 0
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_ownership_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in export."""
+    import typer
+
+    MockClient.from_context.side_effect = typer.Exit(1)
+    result = runner.invoke(app, ["export"])
+    assert result.exit_code == 1
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_typer_exit(
+    _MockContext, MockClient, mock_get_logs, _mock_write, _mock_clean
+):
+    """Cover except typer.Exit: raise in import."""
+    import typer
+
+    MockClient.from_context.side_effect = typer.Exit(1)
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        result = runner.invoke(app, ["import", "ownership.yaml"])
+        assert result.exit_code == 1
+
+
+@patch("preset_cli.cli.superset.lib.clean_logs")
+@patch("preset_cli.cli.superset.lib.write_logs_to_file")
+@patch("preset_cli.cli.superset.lib.get_logs")
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_ownership_continue_on_error_all_success(
+    _MockContext, MockClient, mock_get_logs, _mock_write, mock_clean
+):
+    """Cover clean_logs path when continue_on_error=True and all succeed."""
+    _setup_import_mocks(MockClient, mock_get_logs)
+    with runner.isolated_filesystem():
+        with open("ownership.yaml", "w") as f:
+            yaml.dump(SAMPLE_OWNERSHIP, f)
+        with open("progress.log", "w") as f:
+            pass
+        result = runner.invoke(app, ["import", "ownership.yaml", "--continue-on-error"])
+        assert result.exit_code == 0
+    mock_clean.assert_called_once()

--- a/tests/sup/commands/test_rls.py
+++ b/tests/sup/commands/test_rls.py
@@ -1,0 +1,136 @@
+"""
+Tests for the sup rls export/import commands.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import yaml
+from typer.testing import CliRunner
+
+from sup.commands.rls import app
+
+runner = CliRunner()
+
+SAMPLE_RLS = [
+    {
+        "clause": "client_id = 9",
+        "description": "Rule description",
+        "filter_type": "Regular",
+        "group_key": "department",
+        "name": "Rule name",
+        "roles": ["Gamma"],
+        "tables": ["main.test_table"],
+    },
+]
+
+PATCH_CLIENT = "sup.clients.superset.SupSupersetClient"
+PATCH_CONTEXT = "sup.config.settings.SupContext"
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_rls(_MockContext, MockClient):
+    """Test exporting RLS rules to a YAML file."""
+    mock_client = MagicMock()
+    mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
+    MockClient.from_context.return_value = mock_client
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["export", "rls.yaml"])
+        assert result.exit_code == 0
+
+        with open("rls.yaml") as f:
+            exported = yaml.safe_load(f)
+        assert len(exported) == 1
+        assert exported[0]["name"] == "Rule name"
+        assert exported[0]["clause"] == "client_id = 9"
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_rls_json(_MockContext, MockClient):
+    """Test exporting RLS rules as JSON to stdout."""
+    mock_client = MagicMock()
+    mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
+    MockClient.from_context.return_value = mock_client
+
+    result = runner.invoke(app, ["export", "--json"])
+    assert result.exit_code == 0
+    assert "Rule name" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_rls_porcelain(_MockContext, MockClient):
+    """Test exporting RLS rules in porcelain mode."""
+    mock_client = MagicMock()
+    mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
+    MockClient.from_context.return_value = mock_client
+
+    result = runner.invoke(app, ["export", "--porcelain"])
+    assert result.exit_code == 0
+    assert "Rule name\tmain.test_table" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_rls(_MockContext, MockClient):
+    """Test importing RLS rules from a YAML file."""
+    mock_client = MagicMock()
+    MockClient.from_context.return_value = mock_client
+
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(SAMPLE_RLS, f)
+
+        result = runner.invoke(app, ["import", "rls.yaml"])
+        assert result.exit_code == 0
+
+    mock_client.client.import_rls.assert_called_once_with(SAMPLE_RLS[0])
+
+
+def test_import_rls_dry_run():
+    """Test importing RLS rules with --dry-run."""
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(SAMPLE_RLS, f)
+
+        result = runner.invoke(app, ["import", "rls.yaml", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run" in result.output
+
+
+def test_import_rls_file_not_found():
+    """Test importing from non-existent file."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["import", "nonexistent.yaml"])
+        assert result.exit_code == 1
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_rls_multiple_rules(_MockContext, MockClient):
+    """Test importing multiple RLS rules."""
+    mock_client = MagicMock()
+    MockClient.from_context.return_value = mock_client
+
+    rules = SAMPLE_RLS + [
+        {
+            "clause": "region = 'US'",
+            "description": "US only",
+            "filter_type": "Regular",
+            "group_key": "region",
+            "name": "US Filter",
+            "roles": ["Alpha"],
+            "tables": ["sales"],
+        },
+    ]
+
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(rules, f)
+
+        result = runner.invoke(app, ["import", "rls.yaml"])
+        assert result.exit_code == 0
+
+    assert mock_client.client.import_rls.call_count == 2

--- a/tests/sup/commands/test_rls.py
+++ b/tests/sup/commands/test_rls.py
@@ -1,6 +1,4 @@
-"""
-Tests for the sup rls export/import commands.
-"""
+"""Tests for the sup rls export/import commands."""
 
 from unittest.mock import MagicMock, patch
 
@@ -30,30 +28,24 @@ PATCH_CONTEXT = "sup.config.settings.SupContext"
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
 def test_export_rls(_MockContext, MockClient):
-    """Test exporting RLS rules to a YAML file."""
     mock_client = MagicMock()
     mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
     MockClient.from_context.return_value = mock_client
-
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["export", "rls.yaml"])
         assert result.exit_code == 0
-
         with open("rls.yaml") as f:
             exported = yaml.safe_load(f)
         assert len(exported) == 1
         assert exported[0]["name"] == "Rule name"
-        assert exported[0]["clause"] == "client_id = 9"
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
 def test_export_rls_json(_MockContext, MockClient):
-    """Test exporting RLS rules as JSON to stdout."""
     mock_client = MagicMock()
     mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
     MockClient.from_context.return_value = mock_client
-
     result = runner.invoke(app, ["export", "--json"])
     assert result.exit_code == 0
     assert "Rule name" in result.output
@@ -61,12 +53,21 @@ def test_export_rls_json(_MockContext, MockClient):
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls_porcelain(_MockContext, MockClient):
-    """Test exporting RLS rules in porcelain mode."""
+def test_export_rls_yaml(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
     MockClient.from_context.return_value = mock_client
+    result = runner.invoke(app, ["export", "--yaml"])
+    assert result.exit_code == 0
+    assert "Rule name" in result.output
 
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_rls_porcelain(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
+    MockClient.from_context.return_value = mock_client
     result = runner.invoke(app, ["export", "--porcelain"])
     assert result.exit_code == 0
     assert "Rule name\tmain.test_table" in result.output
@@ -74,46 +75,129 @@ def test_export_rls_porcelain(_MockContext, MockClient):
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
+def test_export_rls_error(_MockContext, MockClient):
+    MockClient.from_context.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["export"])
+    assert result.exit_code == 1
+    assert "Failed to export RLS rules" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_rls_error_porcelain(_MockContext, MockClient):
+    MockClient.from_context.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["export", "--porcelain"])
+    assert result.exit_code == 1
+    assert "Failed" not in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
 def test_import_rls(_MockContext, MockClient):
-    """Test importing RLS rules from a YAML file."""
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
-
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-
         result = runner.invoke(app, ["import", "rls.yaml"])
         assert result.exit_code == 0
-
     mock_client.client.import_rls.assert_called_once_with(SAMPLE_RLS[0])
 
 
-def test_import_rls_dry_run():
-    """Test importing RLS rules with --dry-run."""
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_rls_porcelain(_MockContext, MockClient):
+    mock_client = MagicMock()
+    MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
+        result = runner.invoke(app, ["import", "rls.yaml", "--porcelain"])
+        assert result.exit_code == 0
+        assert "imported:1" in result.output
 
+
+def test_import_rls_dry_run():
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(SAMPLE_RLS, f)
         result = runner.invoke(app, ["import", "rls.yaml", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output
 
 
+def test_import_rls_dry_run_porcelain():
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(SAMPLE_RLS, f)
+        result = runner.invoke(app, ["import", "rls.yaml", "--dry-run", "--porcelain"])
+        assert result.exit_code == 0
+        assert "import\tRule name" in result.output
+
+
 def test_import_rls_file_not_found():
-    """Test importing from non-existent file."""
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["import", "nonexistent.yaml"])
         assert result.exit_code == 1
 
 
+def test_import_rls_file_not_found_porcelain():
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["import", "nonexistent.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "File not found" not in result.output
+
+
+def test_import_rls_empty_file():
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["import", "rls.yaml"])
+        assert result.exit_code == 0
+        assert "No RLS rules found" in result.output
+
+
+def test_import_rls_empty_file_porcelain():
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["import", "rls.yaml", "--porcelain"])
+        assert result.exit_code == 0
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_rls_error(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.import_rls.side_effect = RuntimeError("boom")
+    MockClient.from_context.return_value = mock_client
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(SAMPLE_RLS, f)
+        result = runner.invoke(app, ["import", "rls.yaml"])
+        assert result.exit_code == 1
+        assert "Failed to import RLS rules" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_rls_error_porcelain(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.import_rls.side_effect = RuntimeError("boom")
+    MockClient.from_context.return_value = mock_client
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(SAMPLE_RLS, f)
+        result = runner.invoke(app, ["import", "rls.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "Failed" not in result.output
+
+
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
 def test_import_rls_multiple_rules(_MockContext, MockClient):
-    """Test importing multiple RLS rules."""
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
-
     rules = SAMPLE_RLS + [
         {
             "clause": "region = 'US'",
@@ -125,12 +209,34 @@ def test_import_rls_multiple_rules(_MockContext, MockClient):
             "tables": ["sales"],
         },
     ]
-
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(rules, f)
-
         result = runner.invoke(app, ["import", "rls.yaml"])
         assert result.exit_code == 0
-
     assert mock_client.client.import_rls.call_count == 2
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_rls_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in export."""
+    import typer
+
+    MockClient.from_context.side_effect = typer.Exit(1)
+    result = runner.invoke(app, ["export"])
+    assert result.exit_code == 1
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_rls_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in import."""
+    import typer
+
+    MockClient.from_context.side_effect = typer.Exit(1)
+    with runner.isolated_filesystem():
+        with open("rls.yaml", "w") as f:
+            yaml.dump(SAMPLE_RLS, f)
+        result = runner.invoke(app, ["import", "rls.yaml"])
+        assert result.exit_code == 1

--- a/tests/sup/commands/test_rls.py
+++ b/tests/sup/commands/test_rls.py
@@ -1,4 +1,4 @@
-"""Tests for the sup rls export/import commands."""
+"""Tests for the sup rls pull/push commands."""
 
 from unittest.mock import MagicMock, patch
 
@@ -27,175 +27,175 @@ PATCH_CONTEXT = "sup.config.settings.SupContext"
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls(_MockContext, MockClient):
+def test_pull_rls(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["export", "rls.yaml"])
+        result = runner.invoke(app, ["pull", "rls.yaml"])
         assert result.exit_code == 0
         with open("rls.yaml") as f:
-            exported = yaml.safe_load(f)
-        assert len(exported) == 1
-        assert exported[0]["name"] == "Rule name"
+            pulled = yaml.safe_load(f)
+        assert len(pulled) == 1
+        assert pulled[0]["name"] == "Rule name"
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls_json(_MockContext, MockClient):
+def test_pull_rls_json(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--json"])
+    result = runner.invoke(app, ["pull", "--json"])
     assert result.exit_code == 0
     assert "Rule name" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls_yaml(_MockContext, MockClient):
+def test_pull_rls_yaml(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--yaml"])
+    result = runner.invoke(app, ["pull", "--yaml"])
     assert result.exit_code == 0
     assert "Rule name" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls_porcelain(_MockContext, MockClient):
+def test_pull_rls_porcelain(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_rls.return_value = iter(SAMPLE_RLS)
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--porcelain"])
+    result = runner.invoke(app, ["pull", "--porcelain"])
     assert result.exit_code == 0
     assert "Rule name\tmain.test_table" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls_error(_MockContext, MockClient):
+def test_pull_rls_error(_MockContext, MockClient):
     MockClient.from_context.side_effect = RuntimeError("boom")
-    result = runner.invoke(app, ["export"])
+    result = runner.invoke(app, ["pull"])
     assert result.exit_code == 1
-    assert "Failed to export RLS rules" in result.output
+    assert "Failed to pull RLS rules" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls_error_porcelain(_MockContext, MockClient):
+def test_pull_rls_error_porcelain(_MockContext, MockClient):
     MockClient.from_context.side_effect = RuntimeError("boom")
-    result = runner.invoke(app, ["export", "--porcelain"])
+    result = runner.invoke(app, ["pull", "--porcelain"])
     assert result.exit_code == 1
     assert "Failed" not in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_rls(_MockContext, MockClient):
+def test_push_rls(_MockContext, MockClient):
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-        result = runner.invoke(app, ["import", "rls.yaml"])
+        result = runner.invoke(app, ["push", "rls.yaml"])
         assert result.exit_code == 0
     mock_client.client.import_rls.assert_called_once_with(SAMPLE_RLS[0])
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_rls_porcelain(_MockContext, MockClient):
+def test_push_rls_porcelain(_MockContext, MockClient):
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-        result = runner.invoke(app, ["import", "rls.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "rls.yaml", "--porcelain"])
         assert result.exit_code == 0
-        assert "imported:1" in result.output
+        assert "pushed:1" in result.output
 
 
-def test_import_rls_dry_run():
+def test_push_rls_dry_run():
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-        result = runner.invoke(app, ["import", "rls.yaml", "--dry-run"])
+        result = runner.invoke(app, ["push", "rls.yaml", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output
 
 
-def test_import_rls_dry_run_porcelain():
+def test_push_rls_dry_run_porcelain():
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-        result = runner.invoke(app, ["import", "rls.yaml", "--dry-run", "--porcelain"])
+        result = runner.invoke(app, ["push", "rls.yaml", "--dry-run", "--porcelain"])
         assert result.exit_code == 0
         assert "import\tRule name" in result.output
 
 
-def test_import_rls_file_not_found():
+def test_push_rls_file_not_found():
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["import", "nonexistent.yaml"])
+        result = runner.invoke(app, ["push", "nonexistent.yaml"])
         assert result.exit_code == 1
 
 
-def test_import_rls_file_not_found_porcelain():
+def test_push_rls_file_not_found_porcelain():
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["import", "nonexistent.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "nonexistent.yaml", "--porcelain"])
         assert result.exit_code == 1
         assert "File not found" not in result.output
 
 
-def test_import_rls_empty_file():
+def test_push_rls_empty_file():
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             f.write("")
-        result = runner.invoke(app, ["import", "rls.yaml"])
+        result = runner.invoke(app, ["push", "rls.yaml"])
         assert result.exit_code == 0
         assert "No RLS rules found" in result.output
 
 
-def test_import_rls_empty_file_porcelain():
+def test_push_rls_empty_file_porcelain():
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             f.write("")
-        result = runner.invoke(app, ["import", "rls.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "rls.yaml", "--porcelain"])
         assert result.exit_code == 0
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_rls_error(_MockContext, MockClient):
+def test_push_rls_error(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.import_rls.side_effect = RuntimeError("boom")
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-        result = runner.invoke(app, ["import", "rls.yaml"])
+        result = runner.invoke(app, ["push", "rls.yaml"])
         assert result.exit_code == 1
-        assert "Failed to import RLS rules" in result.output
+        assert "Failed to push RLS rules" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_rls_error_porcelain(_MockContext, MockClient):
+def test_push_rls_error_porcelain(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.import_rls.side_effect = RuntimeError("boom")
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-        result = runner.invoke(app, ["import", "rls.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "rls.yaml", "--porcelain"])
         assert result.exit_code == 1
         assert "Failed" not in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_rls_multiple_rules(_MockContext, MockClient):
+def test_push_rls_multiple_rules(_MockContext, MockClient):
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
     rules = SAMPLE_RLS + [
@@ -212,31 +212,31 @@ def test_import_rls_multiple_rules(_MockContext, MockClient):
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(rules, f)
-        result = runner.invoke(app, ["import", "rls.yaml"])
+        result = runner.invoke(app, ["push", "rls.yaml"])
         assert result.exit_code == 0
     assert mock_client.client.import_rls.call_count == 2
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_rls_typer_exit(_MockContext, MockClient):
-    """Cover except typer.Exit: raise in export."""
+def test_pull_rls_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in pull."""
     import typer
 
     MockClient.from_context.side_effect = typer.Exit(1)
-    result = runner.invoke(app, ["export"])
+    result = runner.invoke(app, ["pull"])
     assert result.exit_code == 1
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_rls_typer_exit(_MockContext, MockClient):
-    """Cover except typer.Exit: raise in import."""
+def test_push_rls_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in push."""
     import typer
 
     MockClient.from_context.side_effect = typer.Exit(1)
     with runner.isolated_filesystem():
         with open("rls.yaml", "w") as f:
             yaml.dump(SAMPLE_RLS, f)
-        result = runner.invoke(app, ["import", "rls.yaml"])
+        result = runner.invoke(app, ["push", "rls.yaml"])
         assert result.exit_code == 1

--- a/tests/sup/commands/test_role.py
+++ b/tests/sup/commands/test_role.py
@@ -1,4 +1,4 @@
-"""Tests for the sup role export/import/sync commands."""
+"""Tests for the sup role pull/push/sync commands."""
 
 from unittest.mock import MagicMock, patch
 
@@ -40,48 +40,48 @@ PATCH_AUTH = "sup.auth.preset.get_preset_auth"
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles(_MockContext, MockClient):
+def test_pull_roles(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["export", "roles.yaml"])
+        result = runner.invoke(app, ["pull", "roles.yaml"])
         assert result.exit_code == 0
         with open("roles.yaml") as f:
-            exported = yaml.safe_load(f)
-        assert len(exported) == 2
-        assert exported[0]["name"] == "Admin"
+            pulled = yaml.safe_load(f)
+        assert len(pulled) == 2
+        assert pulled[0]["name"] == "Admin"
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles_json(_MockContext, MockClient):
+def test_pull_roles_json(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--json"])
+    result = runner.invoke(app, ["pull", "--json"])
     assert result.exit_code == 0
     assert "Admin" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles_yaml(_MockContext, MockClient):
+def test_pull_roles_yaml(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--yaml"])
+    result = runner.invoke(app, ["pull", "--yaml"])
     assert result.exit_code == 0
     assert "Admin" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles_porcelain(_MockContext, MockClient):
+def test_pull_roles_porcelain(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
     MockClient.from_context.return_value = mock_client
-    result = runner.invoke(app, ["export", "--porcelain"])
+    result = runner.invoke(app, ["pull", "--porcelain"])
     assert result.exit_code == 0
     assert "Admin\t2" in result.output
     assert "Gamma\t1" in result.output
@@ -89,120 +89,120 @@ def test_export_roles_porcelain(_MockContext, MockClient):
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles_error(_MockContext, MockClient):
+def test_pull_roles_error(_MockContext, MockClient):
     MockClient.from_context.side_effect = RuntimeError("boom")
-    result = runner.invoke(app, ["export"])
+    result = runner.invoke(app, ["pull"])
     assert result.exit_code == 1
-    assert "Failed to export roles" in result.output
+    assert "Failed to pull roles" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles_error_porcelain(_MockContext, MockClient):
+def test_pull_roles_error_porcelain(_MockContext, MockClient):
     MockClient.from_context.side_effect = RuntimeError("boom")
-    result = runner.invoke(app, ["export", "--porcelain"])
+    result = runner.invoke(app, ["pull", "--porcelain"])
     assert result.exit_code == 1
     assert "Failed" not in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_roles(_MockContext, MockClient):
+def test_push_roles(_MockContext, MockClient):
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-        result = runner.invoke(app, ["import", "roles.yaml"])
+        result = runner.invoke(app, ["push", "roles.yaml"])
         assert result.exit_code == 0
     assert mock_client.client.import_role.call_count == 2
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_roles_porcelain(_MockContext, MockClient):
+def test_push_roles_porcelain(_MockContext, MockClient):
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-        result = runner.invoke(app, ["import", "roles.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "roles.yaml", "--porcelain"])
         assert result.exit_code == 0
-        assert "imported:2" in result.output
+        assert "pushed:2" in result.output
 
 
-def test_import_roles_dry_run():
+def test_push_roles_dry_run():
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-        result = runner.invoke(app, ["import", "roles.yaml", "--dry-run"])
+        result = runner.invoke(app, ["push", "roles.yaml", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output
 
 
-def test_import_roles_dry_run_porcelain():
+def test_push_roles_dry_run_porcelain():
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-        result = runner.invoke(app, ["import", "roles.yaml", "--dry-run", "--porcelain"])
+        result = runner.invoke(app, ["push", "roles.yaml", "--dry-run", "--porcelain"])
         assert result.exit_code == 0
         assert "import\tAdmin" in result.output
 
 
-def test_import_roles_file_not_found():
+def test_push_roles_file_not_found():
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["import", "nonexistent.yaml"])
+        result = runner.invoke(app, ["push", "nonexistent.yaml"])
         assert result.exit_code == 1
 
 
-def test_import_roles_file_not_found_porcelain():
+def test_push_roles_file_not_found_porcelain():
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["import", "nonexistent.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "nonexistent.yaml", "--porcelain"])
         assert result.exit_code == 1
         assert "File not found" not in result.output
 
 
-def test_import_roles_empty_file():
+def test_push_roles_empty_file():
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             f.write("")
-        result = runner.invoke(app, ["import", "roles.yaml"])
+        result = runner.invoke(app, ["push", "roles.yaml"])
         assert result.exit_code == 0
         assert "No roles found" in result.output
 
 
-def test_import_roles_empty_file_porcelain():
+def test_push_roles_empty_file_porcelain():
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             f.write("")
-        result = runner.invoke(app, ["import", "roles.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "roles.yaml", "--porcelain"])
         assert result.exit_code == 0
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_roles_error(_MockContext, MockClient):
+def test_push_roles_error(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.import_role.side_effect = RuntimeError("boom")
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-        result = runner.invoke(app, ["import", "roles.yaml"])
+        result = runner.invoke(app, ["push", "roles.yaml"])
         assert result.exit_code == 1
-        assert "Failed to import roles" in result.output
+        assert "Failed to push roles" in result.output
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_roles_error_porcelain(_MockContext, MockClient):
+def test_push_roles_error_porcelain(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.import_role.side_effect = RuntimeError("boom")
     MockClient.from_context.return_value = mock_client
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-        result = runner.invoke(app, ["import", "roles.yaml", "--porcelain"])
+        result = runner.invoke(app, ["push", "roles.yaml", "--porcelain"])
         assert result.exit_code == 1
         assert "Failed" not in result.output
 
@@ -419,26 +419,26 @@ def test_resolve_teams_multiple_porcelain():
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles_typer_exit(_MockContext, MockClient):
-    """Cover except typer.Exit: raise in export."""
+def test_pull_roles_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in pull."""
     import typer
 
     MockClient.from_context.side_effect = typer.Exit(1)
-    result = runner.invoke(app, ["export"])
+    result = runner.invoke(app, ["pull"])
     assert result.exit_code == 1
 
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_import_roles_typer_exit(_MockContext, MockClient):
-    """Cover except typer.Exit: raise in import."""
+def test_push_roles_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in push."""
     import typer
 
     MockClient.from_context.side_effect = typer.Exit(1)
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-        result = runner.invoke(app, ["import", "roles.yaml"])
+        result = runner.invoke(app, ["push", "roles.yaml"])
         assert result.exit_code == 1
 
 

--- a/tests/sup/commands/test_role.py
+++ b/tests/sup/commands/test_role.py
@@ -1,0 +1,186 @@
+"""
+Tests for the sup role export/import/sync commands.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import yaml
+from typer.testing import CliRunner
+
+from sup.commands.role import app
+
+runner = CliRunner()
+
+SAMPLE_ROLES = [
+    {
+        "name": "Admin",
+        "permissions": ["can read on Database", "can write on Database"],
+    },
+    {
+        "name": "Gamma",
+        "permissions": ["can read on Database"],
+    },
+]
+
+SAMPLE_USER_ROLES = [
+    {
+        "email": "user1@example.com",
+        "team_role": "admin",
+        "workspaces": {
+            "Workspace 1": {
+                "workspace_role": "primary creator",
+            },
+        },
+    },
+]
+
+PATCH_CLIENT = "sup.clients.superset.SupSupersetClient"
+PATCH_CONTEXT = "sup.config.settings.SupContext"
+PATCH_PRESET_CLIENT = "preset_cli.api.clients.preset.PresetClient"
+PATCH_AUTH = "sup.auth.preset.get_preset_auth"
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_roles(_MockContext, MockClient):
+    """Test exporting roles to a YAML file."""
+    mock_client = MagicMock()
+    mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
+    MockClient.from_context.return_value = mock_client
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["export", "roles.yaml"])
+        assert result.exit_code == 0
+
+        with open("roles.yaml") as f:
+            exported = yaml.safe_load(f)
+        assert len(exported) == 2
+        assert exported[0]["name"] == "Admin"
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_roles_json(_MockContext, MockClient):
+    """Test exporting roles as JSON to stdout."""
+    mock_client = MagicMock()
+    mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
+    MockClient.from_context.return_value = mock_client
+
+    result = runner.invoke(app, ["export", "--json"])
+    assert result.exit_code == 0
+    assert "Admin" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_roles_porcelain(_MockContext, MockClient):
+    """Test exporting roles in porcelain mode."""
+    mock_client = MagicMock()
+    mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
+    MockClient.from_context.return_value = mock_client
+
+    result = runner.invoke(app, ["export", "--porcelain"])
+    assert result.exit_code == 0
+    assert "Admin\t2" in result.output
+    assert "Gamma\t1" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_roles(_MockContext, MockClient):
+    """Test importing roles from a YAML file."""
+    mock_client = MagicMock()
+    MockClient.from_context.return_value = mock_client
+
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_ROLES, f)
+
+        result = runner.invoke(app, ["import", "roles.yaml"])
+        assert result.exit_code == 0
+
+    assert mock_client.client.import_role.call_count == 2
+    mock_client.client.import_role.assert_any_call(SAMPLE_ROLES[0])
+    mock_client.client.import_role.assert_any_call(SAMPLE_ROLES[1])
+
+
+def test_import_roles_dry_run():
+    """Test importing roles with --dry-run."""
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_ROLES, f)
+
+        result = runner.invoke(app, ["import", "roles.yaml", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run" in result.output
+
+
+def test_import_roles_file_not_found():
+    """Test importing from non-existent file."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["import", "nonexistent.yaml"])
+        assert result.exit_code == 1
+
+
+# --- Sync tests ---
+
+
+@patch("preset_cli.cli.main.sync_all_user_roles_to_team")
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_sync_roles(_MockContext, _MockAuth, MockClient, mock_sync_all):
+    """Test syncing user roles."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+    mock_client.get_workspaces.return_value = [
+        {"name": "ws1", "title": "Workspace 1", "id": 100, "hostname": "ws1.preset.io"},
+    ]
+
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+
+        result = runner.invoke(app, ["sync", "user_roles.yaml"])
+        assert result.exit_code == 0
+
+    mock_sync_all.assert_called_once()
+
+
+def test_sync_roles_dry_run():
+    """Test syncing with --dry-run."""
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+
+        result = runner.invoke(app, ["sync", "user_roles.yaml", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run" in result.output
+        assert "user1@example.com" in result.output
+
+
+def test_sync_roles_file_not_found():
+    """Test syncing from non-existent file."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["sync", "nonexistent.yaml"])
+        assert result.exit_code == 1
+
+
+@patch("preset_cli.cli.main.sync_all_user_roles_to_team")
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_sync_roles_with_team(_MockContext, _MockAuth, MockClient, mock_sync_all):
+    """Test syncing to a specific team."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "My Team"}]
+    mock_client.get_workspaces.return_value = []
+
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+
+        result = runner.invoke(app, ["sync", "user_roles.yaml", "--team", "My Team"])
+        assert result.exit_code == 0
+
+    mock_sync_all.assert_called_once()

--- a/tests/sup/commands/test_role.py
+++ b/tests/sup/commands/test_role.py
@@ -1,13 +1,11 @@
-"""
-Tests for the sup role export/import/sync commands.
-"""
+"""Tests for the sup role export/import/sync commands."""
 
 from unittest.mock import MagicMock, patch
 
 import yaml
 from typer.testing import CliRunner
 
-from sup.commands.role import app
+from sup.commands.role import _resolve_teams, app
 
 runner = CliRunner()
 
@@ -43,15 +41,12 @@ PATCH_AUTH = "sup.auth.preset.get_preset_auth"
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
 def test_export_roles(_MockContext, MockClient):
-    """Test exporting roles to a YAML file."""
     mock_client = MagicMock()
     mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
     MockClient.from_context.return_value = mock_client
-
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["export", "roles.yaml"])
         assert result.exit_code == 0
-
         with open("roles.yaml") as f:
             exported = yaml.safe_load(f)
         assert len(exported) == 2
@@ -61,11 +56,9 @@ def test_export_roles(_MockContext, MockClient):
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
 def test_export_roles_json(_MockContext, MockClient):
-    """Test exporting roles as JSON to stdout."""
     mock_client = MagicMock()
     mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
     MockClient.from_context.return_value = mock_client
-
     result = runner.invoke(app, ["export", "--json"])
     assert result.exit_code == 0
     assert "Admin" in result.output
@@ -73,12 +66,21 @@ def test_export_roles_json(_MockContext, MockClient):
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
-def test_export_roles_porcelain(_MockContext, MockClient):
-    """Test exporting roles in porcelain mode."""
+def test_export_roles_yaml(_MockContext, MockClient):
     mock_client = MagicMock()
     mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
     MockClient.from_context.return_value = mock_client
+    result = runner.invoke(app, ["export", "--yaml"])
+    assert result.exit_code == 0
+    assert "Admin" in result.output
 
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_roles_porcelain(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.export_roles.return_value = iter(SAMPLE_ROLES)
+    MockClient.from_context.return_value = mock_client
     result = runner.invoke(app, ["export", "--porcelain"])
     assert result.exit_code == 0
     assert "Admin\t2" in result.output
@@ -87,39 +89,122 @@ def test_export_roles_porcelain(_MockContext, MockClient):
 
 @patch(PATCH_CLIENT)
 @patch(PATCH_CONTEXT)
+def test_export_roles_error(_MockContext, MockClient):
+    MockClient.from_context.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["export"])
+    assert result.exit_code == 1
+    assert "Failed to export roles" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_roles_error_porcelain(_MockContext, MockClient):
+    MockClient.from_context.side_effect = RuntimeError("boom")
+    result = runner.invoke(app, ["export", "--porcelain"])
+    assert result.exit_code == 1
+    assert "Failed" not in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
 def test_import_roles(_MockContext, MockClient):
-    """Test importing roles from a YAML file."""
     mock_client = MagicMock()
     MockClient.from_context.return_value = mock_client
-
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-
         result = runner.invoke(app, ["import", "roles.yaml"])
         assert result.exit_code == 0
-
     assert mock_client.client.import_role.call_count == 2
-    mock_client.client.import_role.assert_any_call(SAMPLE_ROLES[0])
-    mock_client.client.import_role.assert_any_call(SAMPLE_ROLES[1])
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_roles_porcelain(_MockContext, MockClient):
+    mock_client = MagicMock()
+    MockClient.from_context.return_value = mock_client
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_ROLES, f)
+        result = runner.invoke(app, ["import", "roles.yaml", "--porcelain"])
+        assert result.exit_code == 0
+        assert "imported:2" in result.output
 
 
 def test_import_roles_dry_run():
-    """Test importing roles with --dry-run."""
     with runner.isolated_filesystem():
         with open("roles.yaml", "w") as f:
             yaml.dump(SAMPLE_ROLES, f)
-
         result = runner.invoke(app, ["import", "roles.yaml", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output
 
 
+def test_import_roles_dry_run_porcelain():
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_ROLES, f)
+        result = runner.invoke(app, ["import", "roles.yaml", "--dry-run", "--porcelain"])
+        assert result.exit_code == 0
+        assert "import\tAdmin" in result.output
+
+
 def test_import_roles_file_not_found():
-    """Test importing from non-existent file."""
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["import", "nonexistent.yaml"])
         assert result.exit_code == 1
+
+
+def test_import_roles_file_not_found_porcelain():
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["import", "nonexistent.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "File not found" not in result.output
+
+
+def test_import_roles_empty_file():
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["import", "roles.yaml"])
+        assert result.exit_code == 0
+        assert "No roles found" in result.output
+
+
+def test_import_roles_empty_file_porcelain():
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["import", "roles.yaml", "--porcelain"])
+        assert result.exit_code == 0
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_roles_error(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.import_role.side_effect = RuntimeError("boom")
+    MockClient.from_context.return_value = mock_client
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_ROLES, f)
+        result = runner.invoke(app, ["import", "roles.yaml"])
+        assert result.exit_code == 1
+        assert "Failed to import roles" in result.output
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_roles_error_porcelain(_MockContext, MockClient):
+    mock_client = MagicMock()
+    mock_client.client.import_role.side_effect = RuntimeError("boom")
+    MockClient.from_context.return_value = mock_client
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_ROLES, f)
+        result = runner.invoke(app, ["import", "roles.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "Failed" not in result.output
 
 
 # --- Sync tests ---
@@ -130,40 +215,82 @@ def test_import_roles_file_not_found():
 @patch(PATCH_AUTH)
 @patch(PATCH_CONTEXT)
 def test_sync_roles(_MockContext, _MockAuth, MockClient, mock_sync_all):
-    """Test syncing user roles."""
     mock_client = MockClient.return_value
     mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
     mock_client.get_workspaces.return_value = [
         {"name": "ws1", "title": "Workspace 1", "id": 100, "hostname": "ws1.preset.io"},
     ]
-
     with runner.isolated_filesystem():
         with open("user_roles.yaml", "w") as f:
             yaml.dump(SAMPLE_USER_ROLES, f)
-
         result = runner.invoke(app, ["sync", "user_roles.yaml"])
         assert result.exit_code == 0
-
     mock_sync_all.assert_called_once()
 
 
-def test_sync_roles_dry_run():
-    """Test syncing with --dry-run."""
+@patch("preset_cli.cli.main.sync_all_user_roles_to_team")
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_sync_roles_porcelain(_MockContext, _MockAuth, MockClient, mock_sync_all):
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+    mock_client.get_workspaces.return_value = []
     with runner.isolated_filesystem():
         with open("user_roles.yaml", "w") as f:
             yaml.dump(SAMPLE_USER_ROLES, f)
+        result = runner.invoke(app, ["sync", "user_roles.yaml", "--porcelain"])
+        assert result.exit_code == 0
+        assert "synced:1" in result.output
 
+
+def test_sync_roles_dry_run():
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
         result = runner.invoke(app, ["sync", "user_roles.yaml", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output
         assert "user1@example.com" in result.output
 
 
+def test_sync_roles_dry_run_porcelain():
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+        result = runner.invoke(app, ["sync", "user_roles.yaml", "--dry-run", "--porcelain"])
+        assert result.exit_code == 0
+        assert "sync\tuser1@example.com" in result.output
+
+
 def test_sync_roles_file_not_found():
-    """Test syncing from non-existent file."""
     with runner.isolated_filesystem():
         result = runner.invoke(app, ["sync", "nonexistent.yaml"])
         assert result.exit_code == 1
+
+
+def test_sync_roles_file_not_found_porcelain():
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["sync", "nonexistent.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "File not found" not in result.output
+
+
+def test_sync_roles_empty_file():
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["sync", "user_roles.yaml"])
+        assert result.exit_code == 0
+        assert "No role definitions" in result.output
+
+
+def test_sync_roles_empty_file_porcelain():
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            f.write("")
+        result = runner.invoke(app, ["sync", "user_roles.yaml", "--porcelain"])
+        assert result.exit_code == 0
 
 
 @patch("preset_cli.cli.main.sync_all_user_roles_to_team")
@@ -171,16 +298,163 @@ def test_sync_roles_file_not_found():
 @patch(PATCH_AUTH)
 @patch(PATCH_CONTEXT)
 def test_sync_roles_with_team(_MockContext, _MockAuth, MockClient, mock_sync_all):
-    """Test syncing to a specific team."""
     mock_client = MockClient.return_value
     mock_client.get_teams.return_value = [{"name": "team1", "title": "My Team"}]
     mock_client.get_workspaces.return_value = []
-
     with runner.isolated_filesystem():
         with open("user_roles.yaml", "w") as f:
             yaml.dump(SAMPLE_USER_ROLES, f)
-
         result = runner.invoke(app, ["sync", "user_roles.yaml", "--team", "My Team"])
         assert result.exit_code == 0
-
     mock_sync_all.assert_called_once()
+
+
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_sync_roles_resolve_empty(_MockContext, _MockAuth, MockClient):
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = []
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+        result = runner.invoke(app, ["sync", "user_roles.yaml"])
+        assert result.exit_code == 0
+
+
+@patch("preset_cli.cli.main.sync_all_user_roles_to_team")
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_sync_roles_error(_MockContext, _MockAuth, MockClient, mock_sync_all):
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+    mock_sync_all.side_effect = RuntimeError("sync failed")
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+        result = runner.invoke(app, ["sync", "user_roles.yaml"])
+        assert result.exit_code == 1
+        assert "Failed to sync roles" in result.output
+
+
+@patch("preset_cli.cli.main.sync_all_user_roles_to_team")
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_sync_roles_error_porcelain(_MockContext, _MockAuth, MockClient, mock_sync_all):
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+    mock_sync_all.side_effect = RuntimeError("sync failed")
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+        result = runner.invoke(app, ["sync", "user_roles.yaml", "--porcelain"])
+        assert result.exit_code == 1
+        assert "Failed" not in result.output
+
+
+# --- _resolve_teams tests ---
+
+
+def test_resolve_teams_with_names():
+    client = MagicMock()
+    client.get_teams.return_value = [
+        {"name": "team1", "title": "My Team"},
+        {"name": "team2", "title": "Other"},
+    ]
+    result = _resolve_teams(client, ["My Team"], porcelain=False)
+    assert result == ["team1"]
+
+
+def test_resolve_teams_not_found():
+    client = MagicMock()
+    client.get_teams.return_value = [{"name": "team1", "title": "My Team"}]
+    result = _resolve_teams(client, ["Nonexistent"], porcelain=False)
+    assert result == []
+
+
+def test_resolve_teams_no_teams():
+    client = MagicMock()
+    client.get_teams.return_value = []
+    result = _resolve_teams(client, None, porcelain=False)
+    assert result == []
+
+
+def test_resolve_teams_no_teams_porcelain():
+    client = MagicMock()
+    client.get_teams.return_value = []
+    result = _resolve_teams(client, None, porcelain=True)
+    assert result == []
+
+
+def test_resolve_teams_single():
+    client = MagicMock()
+    client.get_teams.return_value = [{"name": "team1", "title": "Only"}]
+    result = _resolve_teams(client, None, porcelain=False)
+    assert result == ["team1"]
+
+
+@patch("sup.commands.role.typer.prompt", return_value="team1")
+def test_resolve_teams_multiple_prompt(mock_prompt):
+    client = MagicMock()
+    client.get_teams.return_value = [
+        {"name": "team1", "title": "A"},
+        {"name": "team2", "title": "B"},
+    ]
+    result = _resolve_teams(client, None, porcelain=False)
+    assert result == ["team1"]
+    mock_prompt.assert_called_once()
+
+
+def test_resolve_teams_multiple_porcelain():
+    client = MagicMock()
+    client.get_teams.return_value = [
+        {"name": "team1", "title": "A"},
+        {"name": "team2", "title": "B"},
+    ]
+    result = _resolve_teams(client, None, porcelain=True)
+    assert result == ["team1", "team2"]
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_export_roles_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in export."""
+    import typer
+
+    MockClient.from_context.side_effect = typer.Exit(1)
+    result = runner.invoke(app, ["export"])
+    assert result.exit_code == 1
+
+
+@patch(PATCH_CLIENT)
+@patch(PATCH_CONTEXT)
+def test_import_roles_typer_exit(_MockContext, MockClient):
+    """Cover except typer.Exit: raise in import."""
+    import typer
+
+    MockClient.from_context.side_effect = typer.Exit(1)
+    with runner.isolated_filesystem():
+        with open("roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_ROLES, f)
+        result = runner.invoke(app, ["import", "roles.yaml"])
+        assert result.exit_code == 1
+
+
+@patch("preset_cli.cli.main.sync_all_user_roles_to_team")
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_sync_roles_typer_exit(_MockContext, _MockAuth, MockClient, mock_sync_all):
+    """Cover except typer.Exit: raise in sync."""
+    import typer
+
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+    mock_sync_all.side_effect = typer.Exit(1)
+    with runner.isolated_filesystem():
+        with open("user_roles.yaml", "w") as f:
+            yaml.dump(SAMPLE_USER_ROLES, f)
+        result = runner.invoke(app, ["sync", "user_roles.yaml"])
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- Add `sup rls export/import` for row-level security rules
- Add `sup role export/import/sync` for roles, permissions, and team/workspace role sync
- Add `sup ownership export/import` for asset ownership metadata (with checkpoint support)
- All commands support `--json`, `--yaml`, `--porcelain` output and `--dry-run` for imports

## Test plan
- [ ] Run `pytest tests/sup/commands/test_rls.py tests/sup/commands/test_role.py tests/sup/commands/test_ownership.py`
- [ ] Verify `sup --help` shows "Security & Governance" section
- [ ] Test export/import round-trip with a real workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)