### PR TITLE
feat: add user export, import, and invite commands

### DIFF
--- a/src/sup/commands/dataset_dry.py
+++ b/src/sup/commands/dataset_dry.py
@@ -182,11 +182,11 @@ def dataset_info(
         raise typer.Exit(1)
 
 
-# Export command would follow the same pattern - much cleaner!
-@app.command("export")
-@with_universal_filters  # Could add export-specific filters too
+# Pull command would follow the same pattern - much cleaner!
+@app.command("pull")
+@with_universal_filters  # Could add pull-specific filters too
 @with_output_options
-def export_dataset(
+def pull_dataset(
     filters: UniversalFilters,
     output: OutputOptions,
     folder: Annotated[
@@ -199,21 +199,21 @@ def export_dataset(
     ] = False,
     dry_run: Annotated[
         bool,
-        typer.Option("--dry-run", help="Preview export without writing files"),
+        typer.Option("--dry-run", help="Preview pull without writing files"),
     ] = False,
 ):
     """
-    Export dataset(s) to YAML files.
+    Pull dataset(s) to YAML files.
 
     The decorators automatically provide all the universal filters
     and output options - no need to manually define them!
     """
     console.print(
-        f"{EMOJIS['export']} Exporting datasets...",
+        f"{EMOJIS['export']} Pulling datasets...",
         style=RICH_STYLES["info"],
     )
-    # TODO: Implement dataset export using the filters and output objects
+    # TODO: Implement dataset pull using the filters and output objects
     console.print(
-        f"{EMOJIS['warning']} Dataset export not yet implemented",
+        f"{EMOJIS['warning']} Dataset pull not yet implemented",
         style=RICH_STYLES["warning"],
     )

--- a/src/sup/commands/dataset_dry.py
+++ b/src/sup/commands/dataset_dry.py
@@ -182,11 +182,11 @@ def dataset_info(
         raise typer.Exit(1)
 
 
-# Pull command would follow the same pattern - much cleaner!
-@app.command("pull")
-@with_universal_filters  # Could add pull-specific filters too
+# Export command would follow the same pattern - much cleaner!
+@app.command("export")
+@with_universal_filters  # Could add export-specific filters too
 @with_output_options
-def pull_dataset(
+def export_dataset(
     filters: UniversalFilters,
     output: OutputOptions,
     folder: Annotated[
@@ -199,21 +199,21 @@ def pull_dataset(
     ] = False,
     dry_run: Annotated[
         bool,
-        typer.Option("--dry-run", help="Preview pull without writing files"),
+        typer.Option("--dry-run", help="Preview export without writing files"),
     ] = False,
 ):
     """
-    Pull dataset(s) to YAML files.
+    Export dataset(s) to YAML files.
 
     The decorators automatically provide all the universal filters
     and output options - no need to manually define them!
     """
     console.print(
-        f"{EMOJIS['export']} Pulling datasets...",
+        f"{EMOJIS['export']} Exporting datasets...",
         style=RICH_STYLES["info"],
     )
-    # TODO: Implement dataset pull using the filters and output objects
+    # TODO: Implement dataset export using the filters and output objects
     console.print(
-        f"{EMOJIS['warning']} Dataset pull not yet implemented",
+        f"{EMOJIS['warning']} Dataset export not yet implemented",
         style=RICH_STYLES["warning"],
     )

--- a/src/sup/commands/user.py
+++ b/src/sup/commands/user.py
@@ -1,7 +1,7 @@
 """
 User management commands for sup CLI.
 
-Handles user listing, role management, export/import, and invitations.
+Handles user listing, role management, pull/push, and invitations.
 """
 
 import logging
@@ -196,8 +196,8 @@ def display_user_details(user: dict) -> None:
     )
 
 
-@app.command("export")
-def export_users(
+@app.command("pull")
+def pull_users(
     path: Annotated[
         Path,
         typer.Argument(help="Output file path"),
@@ -214,16 +214,16 @@ def export_users(
     ] = False,
 ):
     """
-    Export users and their workspace roles to a YAML file.
+    Pull users and their workspace roles to a YAML file.
 
-    Exports all users across teams with their team and workspace role assignments.
-    The output format is compatible with 'sup user import'.
+    Pulls all users across teams with their team and workspace role assignments.
+    The output format is compatible with 'sup user push'.
 
     Example:
-        sup user export
-        sup user export users.yaml
-        sup user export --team "My Team"
-        sup user export --json
+        sup user pull
+        sup user pull users.yaml
+        sup user pull --team "My Team"
+        sup user pull --json
     """
     from preset_cli.api.clients.preset import PresetClient
     from preset_cli.cli.export_users import (
@@ -237,7 +237,7 @@ def export_users(
     from sup.output.spinners import spinner
 
     try:
-        with spinner("Exporting users and workspace roles", silent=porcelain) as sp:
+        with spinner("Pulling users and workspace roles", silent=porcelain) as sp:
             ctx = SupContext()
             auth = get_preset_auth(ctx)
             client = PresetClient("https://api.app.preset.io/", auth)
@@ -319,7 +319,7 @@ def export_users(
                 yaml.dump(users_list, output, default_flow_style=False, sort_keys=False)
 
             console.print(
-                f"{EMOJIS['success']} Exported {len(users_list)} users to {path}",
+                f"{EMOJIS['success']} Pulled {len(users_list)} users to {path}",
                 style=RICH_STYLES["success"],
             )
 
@@ -328,14 +328,14 @@ def export_users(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to export users: {e}",
+                f"{EMOJIS['error']} Failed to pull users: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)
 
 
-@app.command("import")
-def import_users_cmd(
+@app.command("push")
+def push_users(
     path: Annotated[
         Path,
         typer.Argument(help="Input YAML file path"),
@@ -354,16 +354,16 @@ def import_users_cmd(
     ] = False,
 ):
     """
-    Import users via SCIM from a YAML file.
+    Push users via SCIM from a YAML file.
 
     Supports two file formats (auto-detected):
     - Simple format: basic user info (email, first_name, last_name)
     - Workspace roles format: user info + workspace role assignments
 
     Example:
-        sup user import users.yaml
-        sup user import users_workspace_roles.yaml --team "My Team"
-        sup user import --dry-run
+        sup user push users.yaml
+        sup user push users_workspace_roles.yaml --team "My Team"
+        sup user push --dry-run
     """
     import yaml
 
@@ -404,8 +404,7 @@ def import_users_cmd(
                     else "simple"
                 )
                 console.print(
-                    f"{EMOJIS['info']} Dry run: would import "
-                    f"{len(users)} users ({fmt_label} format)",
+                    f"{EMOJIS['info']} Dry run: would push {len(users)} users ({fmt_label} format)",
                     style=RICH_STYLES["info"],
                 )
                 for user in users:
@@ -415,7 +414,7 @@ def import_users_cmd(
                     )
             else:
                 for user in users:
-                    print(f"import\t{user.get('email', 'unknown')}")
+                    print(f"push\t{user.get('email', 'unknown')}")
             return
 
         ctx = SupContext()
@@ -427,17 +426,17 @@ def import_users_cmd(
         if not team_names:
             return
 
-        with spinner(f"Importing {len(users)} users", silent=porcelain):
+        with spinner(f"Pushing {len(users)} users", silent=porcelain):
             if file_format == UserFileFormat.WORKSPACE_ROLES:
                 import_users_with_workspace_roles(client, team_names, users)
             else:
                 client.import_users(team_names, users)
 
         if porcelain:
-            print(f"imported:{len(users)}")
+            print(f"pushed:{len(users)}")
         else:
             console.print(
-                f"{EMOJIS['success']} Imported {len(users)} users from {path}",
+                f"{EMOJIS['success']} Pushed {len(users)} users from {path}",
                 style=RICH_STYLES["success"],
             )
 
@@ -446,7 +445,7 @@ def import_users_cmd(
     except Exception as e:
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Failed to import users: {e}",
+                f"{EMOJIS['error']} Failed to push users: {e}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)

--- a/src/sup/commands/user.py
+++ b/src/sup/commands/user.py
@@ -1,18 +1,20 @@
 """
 User management commands for sup CLI.
 
-Handles user listing, role management, and security operations.
+Handles user listing, role management, export/import, and invitations.
 """
 
-from typing import Optional
+import logging
+from pathlib import Path
+from typing import List, Optional
 
 import typer
-
-# Removed: from rich.console import Console
 from typing_extensions import Annotated
 
 from sup.output.console import console
 from sup.output.styles import EMOJIS, RICH_STYLES
+
+_logger = logging.getLogger(__name__)
 
 app = typer.Typer(help="Manage users", no_args_is_help=True)
 
@@ -192,3 +194,398 @@ def display_user_details(user: dict) -> None:
     console.print(
         Panel(panel_content, title=f"User: {full_name}", border_style=RICH_STYLES["brand"])
     )
+
+
+@app.command("export")
+def export_users(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Output file path"),
+    ] = Path("users_workspace_roles.yaml"),
+    teams: Annotated[
+        Optional[List[str]],
+        typer.Option("--team", "-t", help="Filter by team (repeatable)"),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    yaml_output: Annotated[bool, typer.Option("--yaml", help="Output as YAML to stdout")] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Export users and their workspace roles to a YAML file.
+
+    Exports all users across teams with their team and workspace role assignments.
+    The output format is compatible with 'sup user import'.
+
+    Example:
+        sup user export
+        sup user export users.yaml
+        sup user export --team "My Team"
+        sup user export --json
+    """
+    from preset_cli.api.clients.preset import PresetClient
+    from preset_cli.cli.export_users import (
+        convert_user_data_to_list,
+        get_filtered_teams,
+        process_team_members,
+        process_team_workspaces,
+    )
+
+    from sup.auth.preset import get_preset_auth
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        with spinner("Exporting users and workspace roles", silent=porcelain) as sp:
+            ctx = SupContext()
+            auth = get_preset_auth(ctx)
+            client = PresetClient("https://api.app.preset.io/", auth)
+
+            team_filter = set(teams) if teams else set()
+            filtered_teams = get_filtered_teams(client, team_filter)
+
+            if not filtered_teams:
+                if not porcelain:
+                    console.print("No teams found.", style=RICH_STYLES["dim"])
+                return
+
+            # Initialize user data storage
+            from collections import defaultdict
+
+            user_data = defaultdict(
+                lambda: {
+                    "email": None,
+                    "first_name": None,
+                    "last_name": None,
+                    "username": None,
+                    "workspaces": {},
+                },
+            )
+
+            # Role mappings
+            workspace_role_map = {
+                "Admin": "workspace admin",
+                "PresetAlpha": "primary creator",
+                "PresetBeta": "secondary creator",
+                "PresetGamma": "limited creator",
+                "PresetReportsOnly": "viewer",
+                "PresetDashboardsOnly": "dashboard viewer",
+                "PresetNoAccess": "no access",
+                "Alpha": "primary creator",
+                "Beta": "secondary creator",
+                "Gamma": "limited creator",
+                "ReportsOnly": "viewer",
+                "DashboardsOnly": "dashboard viewer",
+                "NoAccess": "no access",
+            }
+            team_role_map = {1: "admin", 2: "user"}
+
+            for team in filtered_teams:
+                team_name = team["name"]
+                team_title = team["title"]
+
+                if sp:
+                    sp.text = f"Processing team: {team_title}"
+
+                process_team_members(
+                    client, team_name, team_title, user_data, team_role_map
+                )
+                process_team_workspaces(
+                    client, team_name, team_title, user_data, workspace_role_map
+                )
+
+            users_list = convert_user_data_to_list(user_data)
+
+            if sp:
+                sp.text = f"Found {len(users_list)} users"
+
+        if json_output:
+            import json
+
+            console.print(json.dumps(users_list, indent=2))
+        elif yaml_output:
+            import yaml
+
+            console.print(yaml.safe_dump(users_list, default_flow_style=False, sort_keys=False))
+        elif porcelain:
+            for user in users_list:
+                email = user.get("email", "")
+                first = user.get("first_name", "")
+                last = user.get("last_name", "")
+                print(f"{email}\t{first}\t{last}")
+        else:
+            import yaml
+
+            with open(path, "w", encoding="utf-8") as output:
+                yaml.dump(users_list, output, default_flow_style=False, sort_keys=False)
+
+            console.print(
+                f"{EMOJIS['success']} Exported {len(users_list)} users to {path}",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to export users: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+@app.command("import")
+def import_users_cmd(
+    path: Annotated[
+        Path,
+        typer.Argument(help="Input YAML file path"),
+    ] = Path("users.yaml"),
+    teams: Annotated[
+        Optional[List[str]],
+        typer.Option("--team", "-t", help="Target team (repeatable)"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview changes without applying"),
+    ] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Import users via SCIM from a YAML file.
+
+    Supports two file formats (auto-detected):
+    - Simple format: basic user info (email, first_name, last_name)
+    - Workspace roles format: user info + workspace role assignments
+
+    Example:
+        sup user import users.yaml
+        sup user import users_workspace_roles.yaml --team "My Team"
+        sup user import --dry-run
+    """
+    import yaml
+
+    from preset_cli.api.clients.preset import PresetClient
+    from preset_cli.cli.main import (
+        UserFileFormat,
+        detect_users_file_format,
+        import_users_with_workspace_roles,
+    )
+
+    from sup.auth.preset import get_preset_auth
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        if not path.exists():
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['error']} File not found: {path}",
+                    style=RICH_STYLES["error"],
+                )
+            raise typer.Exit(1)
+
+        with open(path, encoding="utf-8") as input_:
+            users = yaml.load(input_, Loader=yaml.SafeLoader)
+
+        if not users:
+            if not porcelain:
+                console.print("No users found in file.", style=RICH_STYLES["dim"])
+            return
+
+        file_format = detect_users_file_format(users)
+
+        if dry_run:
+            if not porcelain:
+                fmt_label = "with workspace roles" if file_format == UserFileFormat.WORKSPACE_ROLES else "simple"
+                console.print(
+                    f"{EMOJIS['info']} Dry run: would import {len(users)} users ({fmt_label} format)",
+                    style=RICH_STYLES["info"],
+                )
+                for user in users:
+                    console.print(
+                        f"  - {user.get('email', 'unknown')}",
+                        style=RICH_STYLES["dim"],
+                    )
+            else:
+                for user in users:
+                    print(f"import\t{user.get('email', 'unknown')}")
+            return
+
+        ctx = SupContext()
+        auth = get_preset_auth(ctx)
+        client = PresetClient("https://api.app.preset.io/", auth)
+
+        # Resolve teams
+        team_names = _resolve_teams(client, teams, porcelain)
+        if not team_names:
+            return
+
+        with spinner(f"Importing {len(users)} users", silent=porcelain):
+            if file_format == UserFileFormat.WORKSPACE_ROLES:
+                import_users_with_workspace_roles(client, team_names, users)
+            else:
+                client.import_users(team_names, users)
+
+        if porcelain:
+            print(f"imported:{len(users)}")
+        else:
+            console.print(
+                f"{EMOJIS['success']} Imported {len(users)} users from {path}",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to import users: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+@app.command("invite")
+def invite_users(
+    path: Annotated[
+        Path,
+        typer.Argument(help="YAML file with user emails"),
+    ] = Path("users.yaml"),
+    teams: Annotated[
+        Optional[List[str]],
+        typer.Option("--team", "-t", help="Target team (repeatable)"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview changes without applying"),
+    ] = False,
+    porcelain: Annotated[
+        bool,
+        typer.Option("--porcelain", help="Machine-readable output"),
+    ] = False,
+):
+    """
+    Invite users to join Preset teams.
+
+    Reads a YAML file containing user emails and sends invitations.
+    The YAML file should contain a list of objects with an 'email' field.
+
+    Example:
+        sup user invite users.yaml --team "My Team"
+        sup user invite --dry-run
+    """
+    import yaml
+
+    from preset_cli.api.clients.preset import PresetClient
+
+    from sup.auth.preset import get_preset_auth
+    from sup.config.settings import SupContext
+    from sup.output.spinners import spinner
+
+    try:
+        if not path.exists():
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['error']} File not found: {path}",
+                    style=RICH_STYLES["error"],
+                )
+            raise typer.Exit(1)
+
+        with open(path, encoding="utf-8") as input_:
+            config = yaml.load(input_, Loader=yaml.SafeLoader)
+
+        if not config:
+            if not porcelain:
+                console.print("No users found in file.", style=RICH_STYLES["dim"])
+            return
+
+        emails = [user["email"] for user in config]
+
+        if dry_run:
+            if not porcelain:
+                console.print(
+                    f"{EMOJIS['info']} Dry run: would invite {len(emails)} users",
+                    style=RICH_STYLES["info"],
+                )
+                for email in emails:
+                    console.print(f"  - {email}", style=RICH_STYLES["dim"])
+            else:
+                for email in emails:
+                    print(f"invite\t{email}")
+            return
+
+        ctx = SupContext()
+        auth = get_preset_auth(ctx)
+        client = PresetClient("https://api.app.preset.io/", auth)
+
+        # Resolve teams
+        team_names = _resolve_teams(client, teams, porcelain)
+        if not team_names:
+            return
+
+        with spinner(f"Inviting {len(emails)} users", silent=porcelain):
+            client.invite_users(team_names, emails)
+
+        if porcelain:
+            print(f"invited:{len(emails)}")
+        else:
+            console.print(
+                f"{EMOJIS['success']} Invited {len(emails)} users",
+                style=RICH_STYLES["success"],
+            )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        if not porcelain:
+            console.print(
+                f"{EMOJIS['error']} Failed to invite users: {e}",
+                style=RICH_STYLES["error"],
+            )
+        raise typer.Exit(1)
+
+
+def _resolve_teams(
+    client,
+    teams: Optional[List[str]],
+    porcelain: bool,
+) -> List[str]:
+    """Resolve team names from user input or prompt for selection."""
+    if teams:
+        # Convert team titles to internal names if needed
+        all_teams = client.get_teams()
+        team_name_map = {t["title"]: t["name"] for t in all_teams}
+        team_name_map.update({t["name"]: t["name"] for t in all_teams})
+        resolved = []
+        for t in teams:
+            if t in team_name_map:
+                resolved.append(team_name_map[t])
+            else:
+                _logger.warning("Team '%s' not found, skipping", t)
+        return resolved
+
+    # No teams specified — get all teams
+    all_teams = client.get_teams()
+    if not all_teams:
+        if not porcelain:
+            console.print("No teams found.", style=RICH_STYLES["dim"])
+        return []
+
+    if len(all_teams) == 1:
+        return [all_teams[0]["name"]]
+
+    # Prompt for team selection
+    if not porcelain:
+        console.print("\nAvailable teams:", style=RICH_STYLES["dim"])
+        for t in all_teams:
+            console.print(f"  - {t['title']} ({t['name']})")
+        selected = typer.prompt("Select team name")
+        return [selected]
+
+    return [t["name"] for t in all_teams]

--- a/src/sup/commands/user.py
+++ b/src/sup/commands/user.py
@@ -6,7 +6,7 @@ Handles user listing, role management, export/import, and invitations.
 
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import typer
 from typing_extensions import Annotated
@@ -232,7 +232,6 @@ def export_users(
         process_team_members,
         process_team_workspaces,
     )
-
     from sup.auth.preset import get_preset_auth
     from sup.config.settings import SupContext
     from sup.output.spinners import spinner
@@ -254,7 +253,7 @@ def export_users(
             # Initialize user data storage
             from collections import defaultdict
 
-            user_data = defaultdict(
+            user_data: Dict[str, Dict[str, Any]] = defaultdict(
                 lambda: {
                     "email": None,
                     "first_name": None,
@@ -289,9 +288,7 @@ def export_users(
                 if sp:
                     sp.text = f"Processing team: {team_title}"
 
-                process_team_members(
-                    client, team_name, team_title, user_data, team_role_map
-                )
+                process_team_members(client, team_name, team_title, user_data, team_role_map)
                 process_team_workspaces(
                     client, team_name, team_title, user_data, workspace_role_map
                 )
@@ -376,7 +373,6 @@ def import_users_cmd(
         detect_users_file_format,
         import_users_with_workspace_roles,
     )
-
     from sup.auth.preset import get_preset_auth
     from sup.config.settings import SupContext
     from sup.output.spinners import spinner
@@ -402,9 +398,14 @@ def import_users_cmd(
 
         if dry_run:
             if not porcelain:
-                fmt_label = "with workspace roles" if file_format == UserFileFormat.WORKSPACE_ROLES else "simple"
+                fmt_label = (
+                    "with workspace roles"
+                    if file_format == UserFileFormat.WORKSPACE_ROLES
+                    else "simple"
+                )
                 console.print(
-                    f"{EMOJIS['info']} Dry run: would import {len(users)} users ({fmt_label} format)",
+                    f"{EMOJIS['info']} Dry run: would import "
+                    f"{len(users)} users ({fmt_label} format)",
                     style=RICH_STYLES["info"],
                 )
                 for user in users:
@@ -483,7 +484,6 @@ def invite_users(
     import yaml
 
     from preset_cli.api.clients.preset import PresetClient
-
     from sup.auth.preset import get_preset_auth
     from sup.config.settings import SupContext
     from sup.output.spinners import spinner
@@ -583,8 +583,8 @@ def _resolve_teams(
     # Prompt for team selection
     if not porcelain:
         console.print("\nAvailable teams:", style=RICH_STYLES["dim"])
-        for t in all_teams:
-            console.print(f"  - {t['title']} ({t['name']})")
+        for team in all_teams:
+            console.print(f"  - {team['title']} ({team['name']})")
         selected = typer.prompt("Select team name")
         return [selected]
 

--- a/tests/sup/commands/test_user.py
+++ b/tests/sup/commands/test_user.py
@@ -1,32 +1,47 @@
-"""
-Tests for the sup user export/import/invite commands.
-"""
+"""Tests for sup.commands.user - 100% coverage."""
 
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
 
 import yaml
 from typer.testing import CliRunner
 
-from sup.commands.user import app
+from sup.commands.user import app, display_user_details
 
 runner = CliRunner()
 
-SAMPLE_USERS_SIMPLE = [
+PATCH_PRESET_CLIENT = "preset_cli.api.clients.preset.PresetClient"
+PATCH_AUTH = "sup.auth.preset.get_preset_auth"
+PATCH_CONTEXT = "sup.config.settings.SupContext"
+PATCH_FILTERED = "preset_cli.cli.export_users.get_filtered_teams"
+PATCH_MEMBERS = "preset_cli.cli.export_users.process_team_members"
+PATCH_WORKSPACES = "preset_cli.cli.export_users.process_team_workspaces"
+PATCH_CONVERT = "preset_cli.cli.export_users.convert_user_data_to_list"
+
+SAMPLE_USERS = [
     {
-        "email": "user1@example.com",
-        "first_name": "User",
-        "last_name": "One",
-        "username": "user1",
+        "id": 1,
+        "email": "alice@example.com",
+        "first_name": "Alice",
+        "last_name": "Smith",
+        "username": "alice",
+        "role": ["Admin"],
     },
     {
-        "email": "user2@example.com",
-        "first_name": "User",
-        "last_name": "Two",
-        "username": "user2",
+        "id": 2,
+        "email": "bob@example.com",
+        "first_name": "Bob",
+        "last_name": "Jones",
+        "username": "bob",
+        "role": ["Creator"],
     },
 ]
 
-SAMPLE_USERS_WORKSPACE_ROLES = [
+SIMPLE_USERS = [
+    {"email": "u1@x.com", "first_name": "U", "last_name": "1", "username": "u1"},
+]
+
+WS_ROLES_USERS = [
     {
         "email": "admin@example.com",
         "first_name": "Admin",
@@ -42,163 +57,770 @@ SAMPLE_USERS_WORKSPACE_ROLES = [
     },
 ]
 
-PATCH_PRESET_CLIENT = "preset_cli.api.clients.preset.PresetClient"
-PATCH_AUTH = "sup.auth.preset.get_preset_auth"
-PATCH_CONTEXT = "sup.config.settings.SupContext"
+EXPORT_USERS_LIST = [
+    {"email": "a@b.com", "first_name": "A", "last_name": "B", "username": "ab"},
+    {"email": "c@d.com", "first_name": "C", "last_name": "D", "username": "cd"},
+]
 
 
-# --- Export tests ---
+def _spinner_mocks():
+    cm = MagicMock()
+    obj = MagicMock()
+    cm.__enter__ = MagicMock(return_value=obj)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm, obj
 
 
-@patch("preset_cli.cli.export_users.process_team_workspaces")
-@patch("preset_cli.cli.export_users.process_team_members")
-@patch(PATCH_PRESET_CLIENT)
-@patch(PATCH_AUTH)
-@patch(PATCH_CONTEXT)
-def test_export_users(_MockContext, _MockAuth, MockClient, _mock_members, _mock_workspaces):
-    """Test exporting users to a YAML file."""
-    mock_client = MockClient.return_value
-    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["export", "users.yaml"])
-        assert result.exit_code == 0
+# ---------------------------------------------------------------------------
+# list_users
+# ---------------------------------------------------------------------------
 
 
-@patch(PATCH_PRESET_CLIENT)
-@patch(PATCH_AUTH)
-@patch(PATCH_CONTEXT)
-def test_export_users_no_teams(_MockContext, _MockAuth, MockClient):
-    """Test exporting when no teams found."""
-    mock_client = MockClient.return_value
-    mock_client.get_teams.return_value = []
+class TestListUsers:
+    def test_table_output(self):
+        cm, obj = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
 
-    result = runner.invoke(app, ["export"])
-    assert result.exit_code == 0
-    assert "No teams" in result.output
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["list"])
+        assert r.exit_code == 0
+        mc.display_users_table.assert_called_once()
+        assert obj.text == "Found 2 users"
+
+    def test_json_output(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["list", "--json"])
+        assert r.exit_code == 0
+        assert len(json.loads(r.output)) == 2
+
+    def test_yaml_output(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["list", "--yaml"])
+        assert r.exit_code == 0
+        assert len(yaml.safe_load(r.output)) == 2
+
+    def test_porcelain_output(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm) as mock_ds, patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc), patch(
+            "sup.output.formatters.display_porcelain_list"
+        ) as mock_p:
+            r = runner.invoke(app, ["list", "--porcelain"])
+        assert r.exit_code == 0
+        mock_p.assert_called_once()
+        mock_ds.assert_called_once_with("users", silent=True)
+
+    def test_with_limit(self):
+        cm, obj = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["list", "--limit", "1"])
+        assert r.exit_code == 0
+        assert len(mc.display_users_table.call_args[0][0]) == 1
+
+    def test_spinner_none(self):
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=None)
+        cm.__exit__ = MagicMock(return_value=False)
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["list"])
+        assert r.exit_code == 0
+
+    def test_error(self):
+        cm, _ = _spinner_mocks()
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT, side_effect=RuntimeError("fail")
+        ):
+            r = runner.invoke(app, ["list"])
+        assert r.exit_code == 1
+        assert "Failed to list users" in r.output
+
+    def test_error_porcelain(self):
+        cm, _ = _spinner_mocks()
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT, side_effect=RuntimeError("fail")
+        ):
+            r = runner.invoke(app, ["list", "--porcelain"])
+        assert r.exit_code == 1
+        assert "Failed to list users" not in r.output
 
 
-# --- Import tests ---
+# ---------------------------------------------------------------------------
+# user_info
+# ---------------------------------------------------------------------------
 
 
-@patch(PATCH_PRESET_CLIENT)
-@patch(PATCH_AUTH)
-@patch(PATCH_CONTEXT)
-def test_import_users_simple(_MockContext, _MockAuth, MockClient):
-    """Test importing users in simple format."""
-    mock_client = MockClient.return_value
-    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+class TestUserInfo:
+    def test_found_table(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
 
-    with runner.isolated_filesystem():
-        with open("users.yaml", "w") as f:
-            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc), patch(
+            "sup.commands.user.display_user_details"
+        ) as md:
+            r = runner.invoke(app, ["info", "1"])
+        assert r.exit_code == 0
+        md.assert_called_once()
 
-        result = runner.invoke(app, ["import", "users.yaml"])
-        assert result.exit_code == 0
+    def test_found_porcelain(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
 
-    mock_client.import_users.assert_called_once()
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["info", "1", "--porcelain"])
+        assert r.exit_code == 0
+        assert "1\talice@example.com\tAlice\tSmith" in r.output
+
+    def test_found_json(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["info", "1", "--json"])
+        assert r.exit_code == 0
+        assert json.loads(r.output)["id"] == 1
+
+    def test_found_yaml(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["info", "1", "--yaml"])
+        assert r.exit_code == 0
+        assert yaml.safe_load(r.output)["id"] == 1
+
+    def test_not_found(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["info", "999"])
+        assert r.exit_code == 1
+        assert "User 999 not found" in r.output
+
+    def test_not_found_porcelain(self):
+        cm, _ = _spinner_mocks()
+        mc = MagicMock()
+        mc.client.export_users.return_value = iter(SAMPLE_USERS)
+
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT
+        ), patch("sup.clients.superset.SupSupersetClient.from_context", return_value=mc):
+            r = runner.invoke(app, ["info", "999", "--porcelain"])
+        assert r.exit_code == 1
+        assert "not found" not in r.output
+
+    def test_error(self):
+        cm, _ = _spinner_mocks()
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT, side_effect=RuntimeError("boom")
+        ):
+            r = runner.invoke(app, ["info", "1"])
+        assert r.exit_code == 1
+        assert "Failed to get user info" in r.output
+
+    def test_error_porcelain(self):
+        cm, _ = _spinner_mocks()
+        with patch("sup.output.spinners.data_spinner", return_value=cm), patch(
+            PATCH_CONTEXT, side_effect=RuntimeError("boom")
+        ):
+            r = runner.invoke(app, ["info", "1", "--porcelain"])
+        assert r.exit_code == 1
+        assert "Failed to get user info" not in r.output
 
 
-@patch(PATCH_PRESET_CLIENT)
-@patch(PATCH_AUTH)
-@patch(PATCH_CONTEXT)
-def test_import_users_workspace_roles(_MockContext, _MockAuth, MockClient):
-    """Test importing users with workspace roles format."""
-    mock_client = MockClient.return_value
-    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
-    mock_client.get_team_members.return_value = [
-        {"user": {"email": "admin@example.com", "id": 1}},
-    ]
-    mock_client.get_workspaces.return_value = [
-        {"name": "workspace1", "id": 100, "title": "Workspace1"},
-    ]
-
-    with runner.isolated_filesystem():
-        with open("users.yaml", "w") as f:
-            yaml.dump(SAMPLE_USERS_WORKSPACE_ROLES, f)
-
-        result = runner.invoke(app, ["import", "users.yaml"])
-        assert result.exit_code == 0
+# ---------------------------------------------------------------------------
+# display_user_details
+# ---------------------------------------------------------------------------
 
 
-def test_import_users_dry_run():
-    """Test importing with --dry-run."""
-    with runner.isolated_filesystem():
-        with open("users.yaml", "w") as f:
-            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+class TestDisplayUserDetails:
+    def test_roles_as_list(self):
+        user = {
+            "id": 1,
+            "email": "a@b.com",
+            "first_name": "A",
+            "last_name": "B",
+            "username": "a",
+            "role": ["Admin", "Creator"],
+        }
+        with patch("sup.commands.user.console") as mc:
+            display_user_details(user)
+            assert "Admin, Creator" in mc.print.call_args[0][0].renderable
 
-        result = runner.invoke(app, ["import", "users.yaml", "--dry-run"])
-        assert result.exit_code == 0
-        assert "Dry run" in result.output
-        assert "user1@example.com" in result.output
+    def test_roles_as_string(self):
+        user = {
+            "id": 2,
+            "email": "b@b.com",
+            "first_name": "B",
+            "last_name": "J",
+            "username": "b",
+            "role": "Viewer",
+        }
+        with patch("sup.commands.user.console") as mc:
+            display_user_details(user)
+            assert "Viewer" in mc.print.call_args[0][0].renderable
+
+    def test_empty_roles(self):
+        user = {
+            "id": 3,
+            "email": "c@c.com",
+            "first_name": "C",
+            "last_name": "",
+            "username": "c",
+            "role": [],
+        }
+        with patch("sup.commands.user.console") as mc:
+            display_user_details(user)
+            assert "No roles" in mc.print.call_args[0][0].renderable
+
+    def test_empty_name(self):
+        user = {
+            "id": 4,
+            "email": "d@d.com",
+            "first_name": "",
+            "last_name": "",
+            "username": "anon",
+            "role": [],
+        }
+        with patch("sup.commands.user.console") as mc:
+            display_user_details(user)
+            panel = mc.print.call_args[0][0]
+            assert "Name: Unknown" in panel.renderable
+            assert "Unknown" in panel.title
 
 
-def test_import_users_file_not_found():
-    """Test importing from non-existent file."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["import", "nonexistent.yaml"])
-        assert result.exit_code == 1
+# ---------------------------------------------------------------------------
+# export_users
+# ---------------------------------------------------------------------------
 
 
-# --- Invite tests ---
+class TestExportUsers:
+    @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
+    @patch(PATCH_WORKSPACES)
+    @patch(PATCH_MEMBERS)
+    @patch(PATCH_FILTERED, return_value=[{"name": "t1", "title": "T1"}])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_default_yaml_file(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["export", "out.yaml"])
+            assert r.exit_code == 0
+            assert "Exported 2 users" in r.output
+            with open("out.yaml") as f:
+                assert len(yaml.safe_load(f)) == 2
 
+    @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
+    @patch(PATCH_WORKSPACES)
+    @patch(PATCH_MEMBERS)
+    @patch(PATCH_FILTERED, return_value=[{"name": "t1", "title": "T1"}])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_json_output(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
+        r = runner.invoke(app, ["export", "--json"])
+        assert r.exit_code == 0
+        assert len(json.loads(r.output)) == 2
 
-@patch(PATCH_PRESET_CLIENT)
-@patch(PATCH_AUTH)
-@patch(PATCH_CONTEXT)
-def test_invite_users(_MockContext, _MockAuth, MockClient):
-    """Test inviting users from a YAML file."""
-    mock_client = MockClient.return_value
-    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+    @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
+    @patch(PATCH_WORKSPACES)
+    @patch(PATCH_MEMBERS)
+    @patch(PATCH_FILTERED, return_value=[{"name": "t1", "title": "T1"}])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_yaml_stdout(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
+        r = runner.invoke(app, ["export", "--yaml"])
+        assert r.exit_code == 0
+        assert len(yaml.safe_load(r.output)) == 2
 
-    with runner.isolated_filesystem():
-        with open("users.yaml", "w") as f:
-            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+    @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
+    @patch(PATCH_WORKSPACES)
+    @patch(PATCH_MEMBERS)
+    @patch(PATCH_FILTERED, return_value=[{"name": "t1", "title": "T1"}])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_porcelain_output(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
+        r = runner.invoke(app, ["export", "--porcelain"])
+        assert r.exit_code == 0
+        assert "a@b.com\tA\tB" in r.output
+        assert "c@d.com\tC\tD" in r.output
 
-        result = runner.invoke(app, ["invite", "users.yaml"])
-        assert result.exit_code == 0
+    @patch(PATCH_FILTERED, return_value=[])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_no_teams(self, _ctx, _auth, _c, _ft):
+        r = runner.invoke(app, ["export"])
+        assert r.exit_code == 0
+        assert "No teams" in r.output
 
-    mock_client.invite_users.assert_called_once_with(
-        ["team1"],
-        ["user1@example.com", "user2@example.com"],
+    @patch(PATCH_FILTERED, return_value=[])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_no_teams_porcelain(self, _ctx, _auth, _c, _ft):
+        r = runner.invoke(app, ["export", "--porcelain"])
+        assert r.exit_code == 0
+        assert "No teams" not in r.output
+
+    @patch(PATCH_FILTERED, side_effect=RuntimeError("boom"))
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_error(self, _ctx, _auth, _c, _ft):
+        r = runner.invoke(app, ["export"])
+        assert r.exit_code == 1
+        assert "Failed to export" in r.output
+
+    @patch(PATCH_FILTERED, side_effect=RuntimeError("boom"))
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_error_porcelain(self, _ctx, _auth, _c, _ft):
+        r = runner.invoke(app, ["export", "--porcelain"])
+        assert r.exit_code == 1
+        assert "Failed to export" not in r.output
+
+    @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
+    @patch(PATCH_WORKSPACES)
+    @patch(PATCH_MEMBERS)
+    @patch(
+        PATCH_FILTERED,
+        return_value=[
+            {"name": "t1", "title": "T1"},
+            {"name": "t2", "title": "T2"},
+        ],
     )
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_multiple_teams(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["export", "out.yaml"])
+            assert r.exit_code == 0
+
+    @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
+    @patch(PATCH_WORKSPACES)
+    @patch(PATCH_MEMBERS)
+    @patch(PATCH_FILTERED, return_value=[{"name": "t1", "title": "T1"}])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_team_filter(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["export", "out.yaml", "--team", "T1"])
+            assert r.exit_code == 0
 
 
-def test_invite_users_dry_run():
-    """Test inviting with --dry-run."""
-    with runner.isolated_filesystem():
-        with open("users.yaml", "w") as f:
-            yaml.dump(SAMPLE_USERS_SIMPLE, f)
-
-        result = runner.invoke(app, ["invite", "users.yaml", "--dry-run"])
-        assert result.exit_code == 0
-        assert "Dry run" in result.output
-        assert "user1@example.com" in result.output
+# ---------------------------------------------------------------------------
+# import_users_cmd
+# ---------------------------------------------------------------------------
 
 
-def test_invite_users_file_not_found():
-    """Test inviting from non-existent file."""
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["invite", "nonexistent.yaml"])
-        assert result.exit_code == 1
+class TestImportUsers:
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_simple_format(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml"])
+        assert r.exit_code == 0
+        MC.return_value.import_users.assert_called_once()
+
+    @patch("preset_cli.cli.main.import_users_with_workspace_roles")
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_workspace_roles_format(self, _ctx, _auth, MC, mock_iw):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(WS_ROLES_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml"])
+        assert r.exit_code == 0
+        mock_iw.assert_called_once()
+
+    def test_dry_run(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml", "--dry-run"])
+        assert r.exit_code == 0
+        assert "Dry run" in r.output
+        assert "u1@x.com" in r.output
+
+    def test_dry_run_porcelain(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml", "--dry-run", "--porcelain"])
+        assert r.exit_code == 0
+        assert "import\tu1@x.com" in r.output
+
+    def test_file_not_found(self):
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["import", "missing.yaml"])
+        assert r.exit_code == 1
+        assert "File not found" in r.output
+
+    def test_file_not_found_porcelain(self):
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["import", "missing.yaml", "--porcelain"])
+        assert r.exit_code == 1
+        assert "File not found" not in r.output
+
+    def test_empty_file(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                f.write("")
+            r = runner.invoke(app, ["import", "u.yaml"])
+        assert r.exit_code == 0
+        assert "No users" in r.output
+
+    def test_empty_file_porcelain(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                f.write("")
+            r = runner.invoke(app, ["import", "u.yaml", "--porcelain"])
+        assert r.exit_code == 0
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_no_teams(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = []
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml"])
+        assert r.exit_code == 0
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_porcelain_success(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml", "--porcelain"])
+        assert r.exit_code == 0
+        assert "imported:1" in r.output
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_error(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        MC.return_value.import_users.side_effect = RuntimeError("boom")
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml"])
+        assert r.exit_code == 1
+        assert "Failed to import" in r.output
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_error_porcelain(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        MC.return_value.import_users.side_effect = RuntimeError("boom")
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml", "--porcelain"])
+        assert r.exit_code == 1
+        assert "Failed to import" not in r.output
 
 
-@patch(PATCH_PRESET_CLIENT)
-@patch(PATCH_AUTH)
-@patch(PATCH_CONTEXT)
-def test_invite_users_with_team(_MockContext, _MockAuth, MockClient):
-    """Test inviting users to a specific team."""
-    mock_client = MockClient.return_value
-    mock_client.get_teams.return_value = [{"name": "team1", "title": "My Team"}]
+# ---------------------------------------------------------------------------
+# invite_users
+# ---------------------------------------------------------------------------
 
-    with runner.isolated_filesystem():
-        with open("users.yaml", "w") as f:
-            yaml.dump(SAMPLE_USERS_SIMPLE, f)
 
-        result = runner.invoke(app, ["invite", "users.yaml", "--team", "My Team"])
-        assert result.exit_code == 0
+class TestInviteUsers:
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_success(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml"])
+        assert r.exit_code == 0
+        MC.return_value.invite_users.assert_called_once_with(["t1"], ["u1@x.com"])
 
-    mock_client.invite_users.assert_called_once_with(
-        ["team1"],
-        ["user1@example.com", "user2@example.com"],
-    )
+    def test_dry_run(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml", "--dry-run"])
+        assert r.exit_code == 0
+        assert "Dry run" in r.output
+        assert "u1@x.com" in r.output
+
+    def test_dry_run_porcelain(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml", "--dry-run", "--porcelain"])
+        assert r.exit_code == 0
+        assert "invite\tu1@x.com" in r.output
+
+    def test_file_not_found(self):
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["invite", "missing.yaml"])
+        assert r.exit_code == 1
+        assert "File not found" in r.output
+
+    def test_file_not_found_porcelain(self):
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["invite", "missing.yaml", "--porcelain"])
+        assert r.exit_code == 1
+        assert "File not found" not in r.output
+
+    def test_empty_file(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                f.write("")
+            r = runner.invoke(app, ["invite", "u.yaml"])
+        assert r.exit_code == 0
+        assert "No users" in r.output
+
+    def test_empty_file_porcelain(self):
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                f.write("")
+            r = runner.invoke(app, ["invite", "u.yaml", "--porcelain"])
+        assert r.exit_code == 0
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_with_team(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml", "--team", "T1"])
+        assert r.exit_code == 0
+        MC.return_value.invite_users.assert_called_once_with(["t1"], ["u1@x.com"])
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_no_teams(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = []
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml"])
+        assert r.exit_code == 0
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_porcelain_success(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml", "--porcelain"])
+        assert r.exit_code == 0
+        assert "invited:1" in r.output
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_error(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        MC.return_value.invite_users.side_effect = RuntimeError("boom")
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml"])
+        assert r.exit_code == 1
+        assert "Failed to invite" in r.output
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_error_porcelain(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        MC.return_value.invite_users.side_effect = RuntimeError("boom")
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml", "--porcelain"])
+        assert r.exit_code == 1
+        assert "Failed to invite" not in r.output
+
+
+# ---------------------------------------------------------------------------
+# _resolve_teams (exercised via import/invite)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTeams:
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_team_not_found(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "t1", "title": "T1"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["import", "u.yaml", "--team", "NoSuch"])
+        assert r.exit_code == 0
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_no_teams_non_porcelain(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = []
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml"])
+        assert r.exit_code == 0
+        assert "No teams" in r.output
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_no_teams_porcelain(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = []
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml", "--porcelain"])
+        assert r.exit_code == 0
+        assert "No teams" not in r.output
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_single_team_auto(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [{"name": "only", "title": "Only"}]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml"])
+        assert r.exit_code == 0
+        MC.return_value.invite_users.assert_called_once_with(["only"], ["u1@x.com"])
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_multiple_teams_porcelain(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [
+            {"name": "t1", "title": "T1"},
+            {"name": "t2", "title": "T2"},
+        ]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml", "--porcelain"])
+        assert r.exit_code == 0
+        MC.return_value.invite_users.assert_called_once_with(["t1", "t2"], ["u1@x.com"])
+
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_multiple_teams_interactive(self, _ctx, _auth, MC):
+        MC.return_value.get_teams.return_value = [
+            {"name": "t1", "title": "T1"},
+            {"name": "t2", "title": "T2"},
+        ]
+        with runner.isolated_filesystem():
+            with open("u.yaml", "w") as f:
+                yaml.dump(SIMPLE_USERS, f)
+            r = runner.invoke(app, ["invite", "u.yaml"], input="t1\n")
+        assert r.exit_code == 0
+        assert "Available teams" in r.output
+        MC.return_value.invite_users.assert_called_once_with(["t1"], ["u1@x.com"])
+
+
+class TestExportEdgeCases:
+    """Cover remaining branches in export_users."""
+
+    @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
+    @patch(PATCH_WORKSPACES)
+    @patch(PATCH_MEMBERS)
+    @patch(PATCH_FILTERED, return_value=[{"name": "t1", "title": "T1"}])
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_defaultdict_lambda(self, _ctx, _auth, _c, _ft, mock_members, _w, _cv):
+        """Trigger the defaultdict factory lambda (256->exit branch)."""
+
+        def populate_user_data(client, team_name, team_title, user_data, role_map):
+            _ = user_data["new_user@example.com"]
+
+        mock_members.side_effect = populate_user_data
+        with runner.isolated_filesystem():
+            r = runner.invoke(app, ["export", "out.yaml"])
+            assert r.exit_code == 0
+
+    @patch(PATCH_FILTERED)
+    @patch(PATCH_PRESET_CLIENT)
+    @patch(PATCH_AUTH)
+    @patch(PATCH_CONTEXT)
+    def test_typer_exit_reraise(self, _ctx, _auth, _c, mock_ft):
+        """Cover except typer.Exit: raise (line 327)."""
+        import typer as _typer
+
+        mock_ft.side_effect = _typer.Exit(1)
+        r = runner.invoke(app, ["export"])
+        assert r.exit_code == 1

--- a/tests/sup/commands/test_user.py
+++ b/tests/sup/commands/test_user.py
@@ -2,7 +2,7 @@
 Tests for the sup user export/import/invite commands.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import yaml
 from typer.testing import CliRunner
@@ -55,9 +55,7 @@ PATCH_CONTEXT = "sup.config.settings.SupContext"
 @patch(PATCH_PRESET_CLIENT)
 @patch(PATCH_AUTH)
 @patch(PATCH_CONTEXT)
-def test_export_users(
-    _MockContext, _MockAuth, MockClient, _mock_members, _mock_workspaces
-):
+def test_export_users(_MockContext, _MockAuth, MockClient, _mock_members, _mock_workspaces):
     """Test exporting users to a YAML file."""
     mock_client = MockClient.return_value
     mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]

--- a/tests/sup/commands/test_user.py
+++ b/tests/sup/commands/test_user.py
@@ -1,0 +1,206 @@
+"""
+Tests for the sup user export/import/invite commands.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import yaml
+from typer.testing import CliRunner
+
+from sup.commands.user import app
+
+runner = CliRunner()
+
+SAMPLE_USERS_SIMPLE = [
+    {
+        "email": "user1@example.com",
+        "first_name": "User",
+        "last_name": "One",
+        "username": "user1",
+    },
+    {
+        "email": "user2@example.com",
+        "first_name": "User",
+        "last_name": "Two",
+        "username": "user2",
+    },
+]
+
+SAMPLE_USERS_WORKSPACE_ROLES = [
+    {
+        "email": "admin@example.com",
+        "first_name": "Admin",
+        "last_name": "User",
+        "username": "admin",
+        "workspaces": {
+            "Team/Workspace1": {
+                "workspace_role": "workspace admin",
+                "workspace_name": "workspace1",
+                "team": "Team",
+            },
+        },
+    },
+]
+
+PATCH_PRESET_CLIENT = "preset_cli.api.clients.preset.PresetClient"
+PATCH_AUTH = "sup.auth.preset.get_preset_auth"
+PATCH_CONTEXT = "sup.config.settings.SupContext"
+
+
+# --- Export tests ---
+
+
+@patch("preset_cli.cli.export_users.process_team_workspaces")
+@patch("preset_cli.cli.export_users.process_team_members")
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_export_users(
+    _MockContext, _MockAuth, MockClient, _mock_members, _mock_workspaces
+):
+    """Test exporting users to a YAML file."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["export", "users.yaml"])
+        assert result.exit_code == 0
+
+
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_export_users_no_teams(_MockContext, _MockAuth, MockClient):
+    """Test exporting when no teams found."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = []
+
+    result = runner.invoke(app, ["export"])
+    assert result.exit_code == 0
+    assert "No teams" in result.output
+
+
+# --- Import tests ---
+
+
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_import_users_simple(_MockContext, _MockAuth, MockClient):
+    """Test importing users in simple format."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+
+    with runner.isolated_filesystem():
+        with open("users.yaml", "w") as f:
+            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+
+        result = runner.invoke(app, ["import", "users.yaml"])
+        assert result.exit_code == 0
+
+    mock_client.import_users.assert_called_once()
+
+
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_import_users_workspace_roles(_MockContext, _MockAuth, MockClient):
+    """Test importing users with workspace roles format."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+    mock_client.get_team_members.return_value = [
+        {"user": {"email": "admin@example.com", "id": 1}},
+    ]
+    mock_client.get_workspaces.return_value = [
+        {"name": "workspace1", "id": 100, "title": "Workspace1"},
+    ]
+
+    with runner.isolated_filesystem():
+        with open("users.yaml", "w") as f:
+            yaml.dump(SAMPLE_USERS_WORKSPACE_ROLES, f)
+
+        result = runner.invoke(app, ["import", "users.yaml"])
+        assert result.exit_code == 0
+
+
+def test_import_users_dry_run():
+    """Test importing with --dry-run."""
+    with runner.isolated_filesystem():
+        with open("users.yaml", "w") as f:
+            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+
+        result = runner.invoke(app, ["import", "users.yaml", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run" in result.output
+        assert "user1@example.com" in result.output
+
+
+def test_import_users_file_not_found():
+    """Test importing from non-existent file."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["import", "nonexistent.yaml"])
+        assert result.exit_code == 1
+
+
+# --- Invite tests ---
+
+
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_invite_users(_MockContext, _MockAuth, MockClient):
+    """Test inviting users from a YAML file."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "Team 1"}]
+
+    with runner.isolated_filesystem():
+        with open("users.yaml", "w") as f:
+            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+
+        result = runner.invoke(app, ["invite", "users.yaml"])
+        assert result.exit_code == 0
+
+    mock_client.invite_users.assert_called_once_with(
+        ["team1"],
+        ["user1@example.com", "user2@example.com"],
+    )
+
+
+def test_invite_users_dry_run():
+    """Test inviting with --dry-run."""
+    with runner.isolated_filesystem():
+        with open("users.yaml", "w") as f:
+            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+
+        result = runner.invoke(app, ["invite", "users.yaml", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run" in result.output
+        assert "user1@example.com" in result.output
+
+
+def test_invite_users_file_not_found():
+    """Test inviting from non-existent file."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["invite", "nonexistent.yaml"])
+        assert result.exit_code == 1
+
+
+@patch(PATCH_PRESET_CLIENT)
+@patch(PATCH_AUTH)
+@patch(PATCH_CONTEXT)
+def test_invite_users_with_team(_MockContext, _MockAuth, MockClient):
+    """Test inviting users to a specific team."""
+    mock_client = MockClient.return_value
+    mock_client.get_teams.return_value = [{"name": "team1", "title": "My Team"}]
+
+    with runner.isolated_filesystem():
+        with open("users.yaml", "w") as f:
+            yaml.dump(SAMPLE_USERS_SIMPLE, f)
+
+        result = runner.invoke(app, ["invite", "users.yaml", "--team", "My Team"])
+        assert result.exit_code == 0
+
+    mock_client.invite_users.assert_called_once_with(
+        ["team1"],
+        ["user1@example.com", "user2@example.com"],
+    )

--- a/tests/sup/commands/test_user.py
+++ b/tests/sup/commands/test_user.py
@@ -338,7 +338,7 @@ class TestDisplayUserDetails:
 # ---------------------------------------------------------------------------
 
 
-class TestExportUsers:
+class TestPullUsers:
     @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
     @patch(PATCH_WORKSPACES)
     @patch(PATCH_MEMBERS)
@@ -348,9 +348,9 @@ class TestExportUsers:
     @patch(PATCH_CONTEXT)
     def test_default_yaml_file(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
         with runner.isolated_filesystem():
-            r = runner.invoke(app, ["export", "out.yaml"])
+            r = runner.invoke(app, ["pull", "out.yaml"])
             assert r.exit_code == 0
-            assert "Exported 2 users" in r.output
+            assert "Pulled 2 users" in r.output
             with open("out.yaml") as f:
                 assert len(yaml.safe_load(f)) == 2
 
@@ -362,7 +362,7 @@ class TestExportUsers:
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
     def test_json_output(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
-        r = runner.invoke(app, ["export", "--json"])
+        r = runner.invoke(app, ["pull", "--json"])
         assert r.exit_code == 0
         assert len(json.loads(r.output)) == 2
 
@@ -374,7 +374,7 @@ class TestExportUsers:
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
     def test_yaml_stdout(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
-        r = runner.invoke(app, ["export", "--yaml"])
+        r = runner.invoke(app, ["pull", "--yaml"])
         assert r.exit_code == 0
         assert len(yaml.safe_load(r.output)) == 2
 
@@ -386,7 +386,7 @@ class TestExportUsers:
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
     def test_porcelain_output(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
-        r = runner.invoke(app, ["export", "--porcelain"])
+        r = runner.invoke(app, ["pull", "--porcelain"])
         assert r.exit_code == 0
         assert "a@b.com\tA\tB" in r.output
         assert "c@d.com\tC\tD" in r.output
@@ -396,7 +396,7 @@ class TestExportUsers:
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
     def test_no_teams(self, _ctx, _auth, _c, _ft):
-        r = runner.invoke(app, ["export"])
+        r = runner.invoke(app, ["pull"])
         assert r.exit_code == 0
         assert "No teams" in r.output
 
@@ -405,7 +405,7 @@ class TestExportUsers:
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
     def test_no_teams_porcelain(self, _ctx, _auth, _c, _ft):
-        r = runner.invoke(app, ["export", "--porcelain"])
+        r = runner.invoke(app, ["pull", "--porcelain"])
         assert r.exit_code == 0
         assert "No teams" not in r.output
 
@@ -414,18 +414,18 @@ class TestExportUsers:
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
     def test_error(self, _ctx, _auth, _c, _ft):
-        r = runner.invoke(app, ["export"])
+        r = runner.invoke(app, ["pull"])
         assert r.exit_code == 1
-        assert "Failed to export" in r.output
+        assert "Failed to pull" in r.output
 
     @patch(PATCH_FILTERED, side_effect=RuntimeError("boom"))
     @patch(PATCH_PRESET_CLIENT)
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
     def test_error_porcelain(self, _ctx, _auth, _c, _ft):
-        r = runner.invoke(app, ["export", "--porcelain"])
+        r = runner.invoke(app, ["pull", "--porcelain"])
         assert r.exit_code == 1
-        assert "Failed to export" not in r.output
+        assert "Failed to pull" not in r.output
 
     @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
     @patch(PATCH_WORKSPACES)
@@ -442,7 +442,7 @@ class TestExportUsers:
     @patch(PATCH_CONTEXT)
     def test_multiple_teams(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
         with runner.isolated_filesystem():
-            r = runner.invoke(app, ["export", "out.yaml"])
+            r = runner.invoke(app, ["pull", "out.yaml"])
             assert r.exit_code == 0
 
     @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
@@ -454,7 +454,7 @@ class TestExportUsers:
     @patch(PATCH_CONTEXT)
     def test_team_filter(self, _ctx, _auth, _c, _ft, _m, _w, _cv):
         with runner.isolated_filesystem():
-            r = runner.invoke(app, ["export", "out.yaml", "--team", "T1"])
+            r = runner.invoke(app, ["pull", "out.yaml", "--team", "T1"])
             assert r.exit_code == 0
 
 
@@ -463,7 +463,7 @@ class TestExportUsers:
 # ---------------------------------------------------------------------------
 
 
-class TestImportUsers:
+class TestPushUsers:
     @patch(PATCH_PRESET_CLIENT)
     @patch(PATCH_AUTH)
     @patch(PATCH_CONTEXT)
@@ -472,7 +472,7 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml"])
+            r = runner.invoke(app, ["push", "u.yaml"])
         assert r.exit_code == 0
         MC.return_value.import_users.assert_called_once()
 
@@ -485,7 +485,7 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(WS_ROLES_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml"])
+            r = runner.invoke(app, ["push", "u.yaml"])
         assert r.exit_code == 0
         mock_iw.assert_called_once()
 
@@ -493,7 +493,7 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml", "--dry-run"])
+            r = runner.invoke(app, ["push", "u.yaml", "--dry-run"])
         assert r.exit_code == 0
         assert "Dry run" in r.output
         assert "u1@x.com" in r.output
@@ -502,19 +502,19 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml", "--dry-run", "--porcelain"])
+            r = runner.invoke(app, ["push", "u.yaml", "--dry-run", "--porcelain"])
         assert r.exit_code == 0
-        assert "import\tu1@x.com" in r.output
+        assert "push\tu1@x.com" in r.output
 
     def test_file_not_found(self):
         with runner.isolated_filesystem():
-            r = runner.invoke(app, ["import", "missing.yaml"])
+            r = runner.invoke(app, ["push", "missing.yaml"])
         assert r.exit_code == 1
         assert "File not found" in r.output
 
     def test_file_not_found_porcelain(self):
         with runner.isolated_filesystem():
-            r = runner.invoke(app, ["import", "missing.yaml", "--porcelain"])
+            r = runner.invoke(app, ["push", "missing.yaml", "--porcelain"])
         assert r.exit_code == 1
         assert "File not found" not in r.output
 
@@ -522,7 +522,7 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 f.write("")
-            r = runner.invoke(app, ["import", "u.yaml"])
+            r = runner.invoke(app, ["push", "u.yaml"])
         assert r.exit_code == 0
         assert "No users" in r.output
 
@@ -530,7 +530,7 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 f.write("")
-            r = runner.invoke(app, ["import", "u.yaml", "--porcelain"])
+            r = runner.invoke(app, ["push", "u.yaml", "--porcelain"])
         assert r.exit_code == 0
 
     @patch(PATCH_PRESET_CLIENT)
@@ -541,7 +541,7 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml"])
+            r = runner.invoke(app, ["push", "u.yaml"])
         assert r.exit_code == 0
 
     @patch(PATCH_PRESET_CLIENT)
@@ -552,9 +552,9 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml", "--porcelain"])
+            r = runner.invoke(app, ["push", "u.yaml", "--porcelain"])
         assert r.exit_code == 0
-        assert "imported:1" in r.output
+        assert "pushed:1" in r.output
 
     @patch(PATCH_PRESET_CLIENT)
     @patch(PATCH_AUTH)
@@ -565,9 +565,9 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml"])
+            r = runner.invoke(app, ["push", "u.yaml"])
         assert r.exit_code == 1
-        assert "Failed to import" in r.output
+        assert "Failed to push" in r.output
 
     @patch(PATCH_PRESET_CLIENT)
     @patch(PATCH_AUTH)
@@ -578,9 +578,9 @@ class TestImportUsers:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml", "--porcelain"])
+            r = runner.invoke(app, ["push", "u.yaml", "--porcelain"])
         assert r.exit_code == 1
-        assert "Failed to import" not in r.output
+        assert "Failed to push" not in r.output
 
 
 # ---------------------------------------------------------------------------
@@ -721,7 +721,7 @@ class TestResolveTeams:
         with runner.isolated_filesystem():
             with open("u.yaml", "w") as f:
                 yaml.dump(SIMPLE_USERS, f)
-            r = runner.invoke(app, ["import", "u.yaml", "--team", "NoSuch"])
+            r = runner.invoke(app, ["push", "u.yaml", "--team", "NoSuch"])
         assert r.exit_code == 0
 
     @patch(PATCH_PRESET_CLIENT)
@@ -792,7 +792,7 @@ class TestResolveTeams:
         MC.return_value.invite_users.assert_called_once_with(["t1"], ["u1@x.com"])
 
 
-class TestExportEdgeCases:
+class TestPullEdgeCases:
     """Cover remaining branches in export_users."""
 
     @patch(PATCH_CONVERT, return_value=EXPORT_USERS_LIST)
@@ -810,7 +810,7 @@ class TestExportEdgeCases:
 
         mock_members.side_effect = populate_user_data
         with runner.isolated_filesystem():
-            r = runner.invoke(app, ["export", "out.yaml"])
+            r = runner.invoke(app, ["pull", "out.yaml"])
             assert r.exit_code == 0
 
     @patch(PATCH_FILTERED)
@@ -822,5 +822,5 @@ class TestExportEdgeCases:
         import typer as _typer
 
         mock_ft.side_effect = _typer.Exit(1)
-        r = runner.invoke(app, ["export"])
+        r = runner.invoke(app, ["pull"])
         assert r.exit_code == 1


### PR DESCRIPTION
## Summary
- Add `sup user pull` to export users with workspace roles to YAML
- Add `sup user push` with auto-detection of simple vs workspace-roles format
- Add `sup user invite` to send team invitations from YAML file
- All commands support `--dry-run`, `--porcelain`, and `--team` filtering

PR Description is updated to reflect latest changes

## Test plan
- [ ] Run `pytest tests/sup/commands/test_user.py`
- [ ] Test `sup user export --json` with a real workspace
- [ ] Test import round-trip: export then import to another team

🤖 Generated with [Claude Code](https://claude.com/claude-code)