### PR TITLE
feat: implement dbt core dry-run and dbt_project.yml support

### DIFF
--- a/src/sup/commands/dbt.py
+++ b/src/sup/commands/dbt.py
@@ -42,6 +42,76 @@ def format_dbt_help():
 app = typer.Typer(help=format_dbt_help(), rich_markup_mode="rich", no_args_is_help=True)
 
 
+def _resolve_manifest(file_path: str) -> Path:
+    """
+    Resolve a manifest.json path from either a direct path or a dbt_project.yml.
+
+    If file_path points to a dbt_project.yml, reads it to find target-path
+    and returns the resolved manifest.json path.
+    """
+    import yaml
+
+    path = Path(file_path)
+
+    if path.name == "dbt_project.yml":
+        if not path.exists():
+            return path  # Let caller handle the error
+
+        with open(path, encoding="utf-8") as f:
+            project = yaml.safe_load(f)
+
+        target_path = project.get("target-path", "target")
+        return path.parent / target_path / "manifest.json"
+
+    return path
+
+
+def _dry_run_preview(
+    manifest_path: str,
+    select: Optional[List[str]],
+    exclude: Optional[List[str]],
+    import_db: bool,
+    exposures_path: Optional[str],
+    porcelain: bool,
+) -> None:
+    """Preview what would be synced without making changes."""
+    import json
+
+    from preset_cli.cli.superset.sync.dbt.lib import apply_select
+    from preset_cli.cli.superset.sync.dbt.schemas import ModelSchema
+
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    model_schema = ModelSchema()
+    all_models = []
+    for node in data.get("nodes", {}).values():
+        if node.get("resource_type") == "model":
+            unique_id = node["unique_id"]
+            node["children"] = data.get("child_map", {}).get(unique_id, [])
+            all_models.append(model_schema.load(node))
+
+    selected = apply_select(all_models, tuple(select or []), tuple(exclude or []))
+
+    if porcelain:
+        for model in selected:
+            print(f"{model['name']}\t{model['schema']}\t{model['database']}")
+    else:
+        console.print(
+            f"{EMOJIS['info']} DRY RUN - {len(selected)} models would be synced:",
+            style=RICH_STYLES["info"],
+        )
+        for model in selected:
+            console.print(
+                f"  - {model['name']} ({model['schema']}.{model['database']})",
+                style=RICH_STYLES["dim"],
+            )
+        if import_db:
+            console.print("  Database connection would be imported")
+        if exposures_path:
+            console.print(f"  Exposures would be written to: {exposures_path}")
+
+
 @app.command("core")
 def sync_dbt_core(
     manifest_path: Annotated[
@@ -130,15 +200,18 @@ def sync_dbt_core(
     from sup.clients.superset import SupSupersetClient
     from sup.config.settings import SupContext
 
-    # Validate manifest exists
-    manifest = Path(manifest_path)
+    # Resolve manifest (supports dbt_project.yml)
+    manifest = _resolve_manifest(manifest_path)
     if not manifest.exists():
         if not porcelain:
             console.print(
-                f"{EMOJIS['error']} Manifest file not found: {manifest_path}",
+                f"{EMOJIS['error']} Manifest file not found: {manifest}",
                 style=RICH_STYLES["error"],
             )
         raise typer.Exit(1)
+
+    # Use resolved path for the rest of the command
+    manifest_path = str(manifest)
 
     if not porcelain:
         console.print(
@@ -158,12 +231,7 @@ def sync_dbt_core(
             console.print(f"📝 Will write exposures to: {exposures_path}")
 
     if dry_run:
-        if not porcelain:
-            console.print(
-                f"{EMOJIS['info']} DRY RUN - No changes will be made",
-                style=RICH_STYLES["info"],
-            )
-        # TODO: Implement dry run preview
+        _dry_run_preview(manifest_path, select, exclude, import_db, exposures_path, porcelain)
         return
 
     try:

--- a/tests/sup/commands/dbt_test.py
+++ b/tests/sup/commands/dbt_test.py
@@ -80,19 +80,157 @@ class TestSyncDbtCore:
         assert "DRY RUN" in result.output
         assert result.exit_code == 0
 
-    def test_dry_run_returns_early(self, tmp_path):
+    @patch("preset_cli.cli.superset.sync.dbt.lib.apply_select")
+    @patch("preset_cli.cli.superset.sync.dbt.schemas.ModelSchema")
+    def test_dry_run_with_models(self, mock_schema_cls, mock_apply, tmp_path):
         manifest = tmp_path / "manifest.json"
-        manifest.write_text("{}")
+        manifest.write_text(
+            json.dumps(
+                {
+                    "nodes": {
+                        "model.proj.orders": {
+                            "resource_type": "model",
+                            "unique_id": "model.proj.orders",
+                        }
+                    },
+                    "child_map": {},
+                }
+            )
+        )
+        model = {"name": "orders", "schema": "public", "database": "analytics"}
+        mock_schema_cls.return_value.load.return_value = model
+        mock_apply.return_value = [model]
+
         result = runner.invoke(app, ["core", str(manifest), "--dry-run"])
         assert result.exit_code == 0
         assert "DRY RUN" in result.output
+        assert "1 models would be synced" in result.output
+        assert "orders" in result.output
 
-    def test_dry_run_porcelain(self, tmp_path):
+    @patch("preset_cli.cli.superset.sync.dbt.lib.apply_select")
+    @patch("preset_cli.cli.superset.sync.dbt.schemas.ModelSchema")
+    def test_dry_run_porcelain(self, mock_schema_cls, mock_apply, tmp_path):
         manifest = tmp_path / "manifest.json"
-        manifest.write_text("{}")
+        manifest.write_text(
+            json.dumps(
+                {
+                    "nodes": {
+                        "model.proj.orders": {
+                            "resource_type": "model",
+                            "unique_id": "model.proj.orders",
+                        }
+                    },
+                    "child_map": {},
+                }
+            )
+        )
+        model = {"name": "orders", "schema": "public", "database": "analytics"}
+        mock_schema_cls.return_value.load.return_value = model
+        mock_apply.return_value = [model]
+
         result = runner.invoke(app, ["core", str(manifest), "--dry-run", "--porcelain"])
         assert result.exit_code == 0
+        assert "orders\tpublic\tanalytics" in result.output
         assert "DRY RUN" not in result.output
+
+    @patch("preset_cli.cli.superset.sync.dbt.lib.apply_select")
+    @patch("preset_cli.cli.superset.sync.dbt.schemas.ModelSchema")
+    def test_dry_run_with_import_db_and_exposures(self, mock_schema_cls, mock_apply, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"nodes": {}, "child_map": {}}))
+        mock_schema_cls.return_value = MagicMock()
+        mock_apply.return_value = []
+
+        result = runner.invoke(
+            app,
+            [
+                "core",
+                str(manifest),
+                "--dry-run",
+                "--import-db",
+                "--exposures",
+                "/tmp/exp.yml",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Database connection would be imported" in result.output
+        assert "Exposures would be written to" in result.output
+
+    @patch("preset_cli.cli.superset.sync.dbt.lib.apply_select")
+    @patch("preset_cli.cli.superset.sync.dbt.schemas.ModelSchema")
+    def test_dry_run_no_models(self, mock_schema_cls, mock_apply, tmp_path):
+        """Test dry-run with no model nodes in manifest."""
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"nodes": {}, "child_map": {}}))
+        mock_schema_cls.return_value = MagicMock()
+        mock_apply.return_value = []
+
+        result = runner.invoke(app, ["core", str(manifest), "--dry-run"])
+        assert result.exit_code == 0
+        assert "0 models would be synced" in result.output
+
+    @patch("preset_cli.cli.superset.sync.dbt.lib.apply_select")
+    @patch("preset_cli.cli.superset.sync.dbt.schemas.ModelSchema")
+    def test_dry_run_skips_non_model_nodes(self, mock_schema_cls, mock_apply, tmp_path):
+        """Test dry-run skips non-model nodes (tests, sources, etc.)."""
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "nodes": {
+                        "test.proj.test1": {
+                            "resource_type": "test",
+                            "unique_id": "test.proj.test1",
+                        }
+                    },
+                    "child_map": {},
+                }
+            )
+        )
+        mock_schema_cls.return_value = MagicMock()
+        mock_apply.return_value = []
+
+        result = runner.invoke(app, ["core", str(manifest), "--dry-run"])
+        assert result.exit_code == 0
+        assert "0 models would be synced" in result.output
+
+    def test_dbt_project_yml_resolves_manifest(self, tmp_path):
+        """Test that dbt_project.yml resolves to target/manifest.json."""
+        project = tmp_path / "dbt_project.yml"
+        project.write_text("target-path: custom_target\n")
+        target_dir = tmp_path / "custom_target"
+        target_dir.mkdir()
+        manifest = target_dir / "manifest.json"
+        manifest.write_text(json.dumps({"nodes": {}, "child_map": {}}))
+
+        result = runner.invoke(app, ["core", str(project), "--dry-run"])
+        assert result.exit_code == 0
+
+    def test_dbt_project_yml_default_target(self, tmp_path):
+        """Test dbt_project.yml with default target-path."""
+        project = tmp_path / "dbt_project.yml"
+        project.write_text("name: my_project\n")
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        manifest = target_dir / "manifest.json"
+        manifest.write_text(json.dumps({"nodes": {}, "child_map": {}}))
+
+        result = runner.invoke(app, ["core", str(project), "--dry-run"])
+        assert result.exit_code == 0
+
+    def test_dbt_project_yml_not_found(self, tmp_path):
+        """Test dbt_project.yml that doesn't exist."""
+        result = runner.invoke(app, ["core", str(tmp_path / "dbt_project.yml")])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_dbt_project_yml_manifest_not_found(self, tmp_path):
+        """Test dbt_project.yml where resolved manifest doesn't exist."""
+        project = tmp_path / "dbt_project.yml"
+        project.write_text("target-path: nonexistent\n")
+        result = runner.invoke(app, ["core", str(project)])
+        assert result.exit_code == 1
+        assert "not found" in result.output
 
     def test_success_with_workspace_id(self, tmp_path):
         manifest = tmp_path / "manifest.json"


### PR DESCRIPTION
## Summary
- Implement dry-run preview for `sup dbt core` showing models that would be synced
- Add support for `dbt_project.yml` as input file (auto-resolves to manifest.json)
- Dry-run in porcelain mode outputs tab-separated model list for automation

## Test plan
- [ ] Run `pytest tests/sup/commands/dbt_test.py`
- [ ] Test dry-run: `sup dbt core manifest.json --dry-run`
- [ ] Test dbt_project.yml: `sup dbt core dbt_project.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)