### PR TITLE
chore: regenerate CLI docs and add feature parity page

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -43,6 +43,12 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Reference',
+          items: [
+            { label: 'Feature Parity', link: '/feature-parity' },
+          ],
+        },
+        {
           label: 'Guides',
           items: [
             { label: 'Cross-Workspace Sync', link: '/guides/cross-workspace' },

--- a/docs-site/src/content/docs/commands/dashboard.mdx
+++ b/docs-site/src/content/docs/commands/dashboard.mdx
@@ -18,6 +18,7 @@ sup dashboard [COMMAND] [OPTIONS]
 | `sup dashboard list` | List dashboards in the current or specified workspace |
 | `sup dashboard info` | Show detailed information about a dashboard |
 | `sup dashboard pull` | Pull dashboard definitions from Superset workspace to local filesystem |
+| `sup dashboard push` | Push dashboard definitions from local filesystem to Superset workspace |
 
 ## Examples
 

--- a/docs-site/src/content/docs/commands/database.mdx
+++ b/docs-site/src/content/docs/commands/database.mdx
@@ -18,6 +18,7 @@ sup database [COMMAND] [OPTIONS]
 | `sup database list` | List all databases in the current or specified workspace |
 | `sup database use` | Set the default database for SQL queries |
 | `sup database info` | Show detailed information about a database |
+| `sup database pull` | Pull database configurations from Superset workspace to local filesystem |
 
 ## Examples
 

--- a/docs-site/src/content/docs/commands/dataset.mdx
+++ b/docs-site/src/content/docs/commands/dataset.mdx
@@ -18,6 +18,7 @@ sup dataset [COMMAND] [OPTIONS]
 | `sup dataset list` | List datasets in the current or specified workspace |
 | `sup dataset info` | Show detailed information about a dataset |
 | `sup dataset pull` | Pull dataset definitions from Superset workspace to local filesystem |
+| `sup dataset push` | Push dataset definitions from local filesystem to Superset workspace |
 
 ## Examples
 

--- a/docs-site/src/content/docs/commands/dbt.mdx
+++ b/docs-site/src/content/docs/commands/dbt.mdx
@@ -11,7 +11,7 @@ description: "dbt to Superset synchronization"
 - Database sync: dbt profiles → Superset database connections
 - Exposures: Superset charts/dashboards → dbt exposures
 - Selective sync: Use --select and --exclude for model filtering
-- Metadata preservation: Keep Superset customizations with --preserve-metadata
+- Metadata preservation: Keep Superset customizations
 
 
 ## Supported Sources

--- a/docs-site/src/content/docs/commands/group.mdx
+++ b/docs-site/src/content/docs/commands/group.mdx
@@ -1,0 +1,32 @@
+---
+title: "sup group"
+description: "Manage SCIM groups"
+---
+
+Manage SCIM groups
+
+## Usage
+
+```bash
+sup group [COMMAND] [OPTIONS]
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `sup group list` | List all SCIM groups in a Preset team |
+| `sup group sync` | Synchronize SCIM groups from a YAML configuration file |
+| `sup group create` | Create a new SCIM group in a Preset team |
+
+## Examples
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs>
+  <TabItem label="Basic usage">
+    ```bash
+    sup group
+    ```
+  </TabItem>
+</Tabs>

--- a/docs-site/src/content/docs/commands/ownership.mdx
+++ b/docs-site/src/content/docs/commands/ownership.mdx
@@ -1,0 +1,31 @@
+---
+title: "sup ownership"
+description: "Manage asset ownership"
+---
+
+Manage asset ownership
+
+## Usage
+
+```bash
+sup ownership [COMMAND] [OPTIONS]
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `sup ownership pull` | Pull asset ownership to a YAML file |
+| `sup ownership push` | Push asset ownership from a YAML file |
+
+## Examples
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs>
+  <TabItem label="Basic usage">
+    ```bash
+    sup ownership
+    ```
+  </TabItem>
+</Tabs>

--- a/docs-site/src/content/docs/commands/rls.mdx
+++ b/docs-site/src/content/docs/commands/rls.mdx
@@ -1,0 +1,31 @@
+---
+title: "sup rls"
+description: "Manage row-level security"
+---
+
+Manage row-level security
+
+## Usage
+
+```bash
+sup rls [COMMAND] [OPTIONS]
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `sup rls pull` | Pull RLS rules to a YAML file |
+| `sup rls push` | Push RLS rules from a YAML file |
+
+## Examples
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs>
+  <TabItem label="Basic usage">
+    ```bash
+    sup rls
+    ```
+  </TabItem>
+</Tabs>

--- a/docs-site/src/content/docs/commands/role.mdx
+++ b/docs-site/src/content/docs/commands/role.mdx
@@ -1,0 +1,32 @@
+---
+title: "sup role"
+description: "Manage roles and permissions"
+---
+
+Manage roles and permissions
+
+## Usage
+
+```bash
+sup role [COMMAND] [OPTIONS]
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `sup role pull` | Pull roles and permissions to a YAML file |
+| `sup role push` | Push roles and permissions from a YAML file |
+| `sup role sync` | Sync team, workspace, and data access roles from a YAML file |
+
+## Examples
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs>
+  <TabItem label="Basic usage">
+    ```bash
+    sup role
+    ```
+  </TabItem>
+</Tabs>

--- a/docs-site/src/content/docs/commands/sync.mdx
+++ b/docs-site/src/content/docs/commands/sync.mdx
@@ -40,6 +40,7 @@ sup sync [COMMAND] [OPTIONS]
 | `sup sync run` | Run a multi-target sync operation |
 | `sup sync create` | Create a new sync configuration folder with example config |
 | `sup sync validate` | Validate a sync configuration folder |
+| `sup sync native` | Push assets from a directory of YAML files (native sync) |
 
 ## Examples
 

--- a/docs-site/src/content/docs/commands/user.mdx
+++ b/docs-site/src/content/docs/commands/user.mdx
@@ -17,6 +17,9 @@ sup user [COMMAND] [OPTIONS]
 |---------|-------------|
 | `sup user list` | List all users in the current or specified workspace |
 | `sup user info` | Show detailed information about a user |
+| `sup user pull` | Pull users and their workspace roles to a YAML file |
+| `sup user push` | Push users via SCIM from a YAML file |
+| `sup user invite` | Invite users to join Preset teams |
 
 ## Examples
 

--- a/docs-site/src/content/docs/feature-parity.md
+++ b/docs-site/src/content/docs/feature-parity.md
@@ -1,0 +1,49 @@
+---
+title: "Feature Parity"
+description: "Legacy preset-cli to sup CLI feature parity mapping"
+---
+
+# Feature Parity: Legacy preset-cli → sup CLI
+
+## preset-cli (team-level commands)
+
+| Legacy Command | sup Equivalent | Status |
+|---|---|---|
+| `auth` | `sup config auth` | ✅ |
+| `invite-users` | `sup user invite` | ✅ |
+| `import-users` | `sup user push` | ✅ |
+| `export-users` | `sup user pull` | ✅ |
+| `sync-roles` | `sup role sync` | ✅ |
+| `list-group-membership` | `sup group list` | ✅ |
+
+## superset-cli (workspace-level commands)
+
+| Legacy Command | sup Equivalent | Status |
+|---|---|---|
+| `sql` | `sup sql` | ✅ |
+| `export-assets` | `sup chart/dashboard/dataset/database pull` | ✅ |
+| `export-users` | `sup user list` | ✅ |
+| `export-rls` | `sup rls pull` | ✅ |
+| `export-roles` | `sup role pull` | ✅ |
+| `export-ownership` | `sup ownership pull` | ✅ |
+| `import-rls` | `sup rls push` | ✅ |
+| `import-roles` | `sup role push` | ✅ |
+| `import-ownership` | `sup ownership push` | ✅ |
+| `import-assets` / `sync native` | `sup sync native` | ✅ |
+| `sync dbt-core` | `sup dbt core` | ✅ |
+| `sync dbt-cloud` | `sup dbt cloud` | ✅ |
+
+## sup additions (no legacy equivalent)
+
+| Command | Description |
+|---|---|
+| `sup workspace list/use/info/set-target/show` | Workspace context management |
+| `sup database list/use/info/pull` | Database management + pull |
+| `sup dataset list/info/pull/push` | Dataset discovery + pull/push |
+| `sup chart list/info/pull/push` | Full chart lifecycle |
+| `sup dashboard list/info/pull/push` | Full dashboard lifecycle |
+| `sup query list/info` | Saved query discovery |
+| `sup group sync/create` | SCIM group management |
+| `sup sync run/create/validate` | Multi-target sync framework |
+| `sup dbt list-models` | dbt model preview |
+| `sup config show/set/env/init` | Modern config management |


### PR DESCRIPTION
## Summary
- Regenerate command reference docs for new commands (rls, role, ownership, sync native, group)
- Add feature parity reference page mapping all legacy preset-cli commands to sup equivalents
- Add Reference section to docs sidebar

## Test plan
- [ ] Run `cd docs-site && npm run dev` and verify new pages render
- [ ] Check Feature Parity page in sidebar under Reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)