### PR TITLE
chore: update changelog for v0.1.4 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Changelog
 Next
 ====
 
+Version 0.1.4 - 2026-05-06
+===========================
+
+- Added theme management commands: ``sup theme pull``, ``sup theme push``, and ``sup theme sync`` for git-like theme lifecycle across workspaces (`#49 <https://github.com/preset-io/superset-sup/pull/49>`_).
+
 Version 0.1.3 - 2026-04-14
 ===========================
 


### PR DESCRIPTION
## Summary
- Adds the v0.1.4 changelog entry covering theme pull/push/sync ([#49](https://github.com/preset-io/superset-sup/pull/49))

## Test plan
- [ ] Review the changelog entry renders correctly
- [ ] After merge, tag `v0.1.4` on the merge commit and publish GitHub Release to trigger PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)