### PR TITLE
fix: apply --id, --ids, and --database-id filters in sup dataset list

### DIFF
--- a/src/sup/clients/superset.py
+++ b/src/sup/clients/superset.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional
 # Removed: from rich.console import Console
 from rich.table import Table
 
-from preset_cli.api.clients.superset import SupersetClient
+from preset_cli.api.clients.superset import MAX_PAGE_SIZE, SupersetClient
 from sup.auth.preset import SupPresetAuth
 from sup.config.settings import SupContext
 from sup.output.console import console
@@ -186,26 +186,32 @@ class SupSupersetClient:
         limit: Optional[int] = None,
         page: int = 0,
         text_search: Optional[str] = None,
+        filters: Optional[List[Dict[str, Any]]] = None,
+        fetch_all: bool = False,
     ) -> List[Dict[str, Any]]:
-        """Get datasets with fast pagination - only fetch what we need."""
+        """
+        Get datasets, optionally filtered server-side.
+
+        Args:
+            silent: Suppress the result count message.
+            limit: Page size for a single-page fetch (ignored when ``fetch_all``).
+            page: Page index for a single-page fetch.
+            text_search: Substring match on ``table_name`` (server-side).
+            filters: Extra Superset filter dicts (``{"col", "opr", "value"}``)
+                applied server-side, e.g. id/database filters.
+            fetch_all: When True, paginate until exhausted so filters apply to the
+                whole workspace rather than just the first page.
+        """
         try:
             # Use direct API call to fetch only one page instead of everything
             import prison
 
             from preset_cli.lib import validate_response
 
-            # Build query for single page fetch with optional search
-            query_params: Dict[str, Any] = {
-                "filters": [],
-                "order_column": "changed_on_delta_humanized",  # API default
-                "order_direction": "desc",
-                "page": page,
-                "page_size": limit or 50,  # Use our limit as page_size
-            }
-
-            # Add text search parameter if provided (ct operator from network monitoring)
+            # Filters applied server-side: text search plus any caller-supplied ones
+            api_filters: List[Dict[str, Any]] = list(filters) if filters else []
             if text_search:
-                query_params["filters"].append(
+                api_filters.append(
                     {
                         "col": "table_name",
                         "opr": "ct",  # contains operator for dataset search
@@ -213,13 +219,32 @@ class SupSupersetClient:
                     },
                 )
 
-            query = prison.dumps(query_params)
+            datasets: List[Dict[str, Any]] = []
+            current_page = page
+            # MAX_PAGE_SIZE mirrors the legacy paginating client (get_resources)
+            page_size = MAX_PAGE_SIZE if fetch_all else (limit or 50)
 
-            url = self.client.baseurl / "api/v1/dataset/" % {"q": query}
-            response = self.client.session.get(url)
-            validate_response(response)
+            while True:
+                query_params: Dict[str, Any] = {
+                    "filters": api_filters,
+                    "order_column": "changed_on_delta_humanized",  # API default
+                    "order_direction": "desc",
+                    "page": current_page,
+                    "page_size": page_size,
+                }
 
-            datasets = response.json()["result"]
+                query = prison.dumps(query_params)
+                url = self.client.baseurl / "api/v1/dataset/" % {"q": query}
+                response = self.client.session.get(url)
+                validate_response(response)
+
+                result = response.json()["result"]
+                datasets.extend(result)
+
+                # Single-page mode (default) or last page reached
+                if not fetch_all or not result:
+                    break
+                current_page += 1
 
             if not silent:
                 console.print(

--- a/src/sup/commands/dataset.py
+++ b/src/sup/commands/dataset.py
@@ -121,19 +121,39 @@ def list_datasets(
     from sup.output.spinners import data_spinner
 
     try:
-        # No complex filtering - just simple server-side search
+        # Build server-side filters so the API returns only matching datasets,
+        # paginated in full (avoids the single-page cap that would drop matches
+        # in large workspaces). Column/operator choices verified against the API:
+        #   id eq <n> | id in [<n>...] | database rel_o_m <db_id>
+        from sup.filters.base import UniversalFilters
 
-        # Get datasets from API with spinner (using server-side filtering for performance)
+        api_filters: List[Dict[str, Any]] = []
+        if id_filter:
+            api_filters.append({"col": "id", "opr": "eq", "value": id_filter})
+        elif ids_filter:
+            id_list = UniversalFilters.parse_ids(ids_filter)
+            api_filters.append({"col": "id", "opr": "in", "value": id_list})
+
+        if database_id is not None:
+            api_filters.append({"col": "database", "opr": "rel_o_m", "value": database_id})
+
+        # Get datasets from API with spinner (server-side filtering for performance)
         with data_spinner("datasets", silent=porcelain) as sp:
             ctx = SupContext()
             client = SupSupersetClient.from_context(ctx, workspace_id)
 
-            # Use server-side filtering only - no client-side nonsense
             datasets = client.get_datasets(
                 silent=True,
                 limit=limit_filter,
                 text_search=search_filter,  # Server-side table name search
+                filters=api_filters,
+                # When filtering, fetch every page so matches aren't capped to page 1
+                fetch_all=bool(api_filters),
             )
+
+            # Apply limit after server-side filtering (page-spanning result set)
+            if api_filters and limit_filter:
+                datasets = datasets[:limit_filter]
 
             # Update spinner with results
             if sp:

--- a/tests/sup/clients/superset_test.py
+++ b/tests/sup/clients/superset_test.py
@@ -1,0 +1,89 @@
+"""Tests for SupSupersetClient.get_datasets server-side filtering & pagination."""
+
+from unittest.mock import MagicMock
+
+import prison
+from yarl import URL
+
+from sup.clients.superset import SupSupersetClient
+
+
+def _make_client(pages):
+    """Build a SupSupersetClient whose session.get returns the given pages in order.
+
+    ``pages`` is a list of result-lists; each call to session.get pops the next one.
+    """
+    client = SupSupersetClient.__new__(SupSupersetClient)  # bypass __init__/auth
+    inner = MagicMock()
+    inner.baseurl = URL("http://superset.test/")
+
+    responses = []
+    for page in pages:
+        resp = MagicMock()
+        resp.json.return_value = {"result": page}
+        resp.status_code = 200
+        responses.append(resp)
+    inner.session.get.side_effect = responses
+    client.client = inner
+    return client, inner
+
+
+def _query_of(call):
+    """Extract and decode the prison-encoded ``q`` from a session.get call's URL."""
+    url = call.args[0]
+    return prison.loads(str(url).split("q=", 1)[1])
+
+
+def test_single_page_by_default():
+    """Without fetch_all, only one request is made and limit drives page_size."""
+    client, inner = _make_client([[{"id": 1}, {"id": 2}]])
+
+    result = client.get_datasets(silent=True, limit=25)
+
+    assert [d["id"] for d in result] == [1, 2]
+    assert inner.session.get.call_count == 1
+    q = _query_of(inner.session.get.call_args)
+    assert q["page_size"] == 25
+    assert q["filters"] == []
+
+
+def test_fetch_all_paginates_until_empty():
+    """With fetch_all, it keeps requesting pages until the API returns none."""
+    client, inner = _make_client([[{"id": 1}], [{"id": 2}], []])
+
+    result = client.get_datasets(silent=True, fetch_all=True)
+
+    assert [d["id"] for d in result] == [1, 2]
+    # 2 full pages + 1 empty page that stops the loop
+    assert inner.session.get.call_count == 3
+    first_q = _query_of(inner.session.get.call_args_list[0])
+    assert first_q["page_size"] == 100  # MAX_PAGE_SIZE
+    assert first_q["page"] == 0
+    assert _query_of(inner.session.get.call_args_list[1])["page"] == 1
+
+
+def test_filters_and_text_search_combined():
+    """Caller filters and text_search are both sent server-side."""
+    client, inner = _make_client([[{"id": 3}], []])
+
+    client.get_datasets(
+        silent=True,
+        filters=[{"col": "id", "opr": "eq", "value": 3}],
+        text_search="sales",
+        fetch_all=True,
+    )
+
+    q = _query_of(inner.session.get.call_args_list[0])
+    assert {"col": "id", "opr": "eq", "value": 3} in q["filters"]
+    assert {"col": "table_name", "opr": "ct", "value": "sales"} in q["filters"]
+
+
+def test_error_returns_empty_list():
+    """A failing request yields an empty list rather than raising."""
+    client = SupSupersetClient.__new__(SupSupersetClient)
+    inner = MagicMock()
+    inner.baseurl = URL("http://superset.test/")
+    inner.session.get.side_effect = RuntimeError("boom")
+    client.client = inner
+
+    assert client.get_datasets(silent=True) == []

--- a/tests/sup/commands/dataset_test.py
+++ b/tests/sup/commands/dataset_test.py
@@ -53,7 +53,7 @@ SAMPLE_DATASETS = [
     {
         "id": 1,
         "table_name": "sales",
-        "database": {"database_name": "main_db"},
+        "database": {"id": 1, "database_name": "main_db"},
         "schema": "public",
         "kind": "physical",
         "columns": [{"column_name": "id", "type": "INT", "description": ""}],
@@ -62,7 +62,7 @@ SAMPLE_DATASETS = [
     {
         "id": 2,
         "table_name": "users",
-        "database": {"database_name": "main_db"},
+        "database": {"id": 2, "database_name": "main_db"},
         "schema": "public",
         "kind": "physical",
         "columns": [],
@@ -174,6 +174,111 @@ class TestListDatasets:
 
         result = runner.invoke(app, ["list", "--porcelain"])
         assert result.exit_code == 1
+
+    @patch(PATCH_SPINNER)
+    @patch(PATCH_CLIENT)
+    @patch(PATCH_CTX)
+    def test_id_filter_server_side(self, mock_ctx_cls, mock_client_cls, mock_spinner):
+        """--id is pushed to the API as an eq filter with full pagination."""
+        cm, sp = _make_spinner_mock()
+        mock_spinner.return_value = cm
+        mock_ctx_cls.return_value = MagicMock()
+        client = MagicMock()
+        mock_client_cls.from_context.return_value = client
+        client.get_datasets.return_value = [SAMPLE_DATASETS[0]]
+
+        result = runner.invoke(app, ["list", "--id", "1", "--json"])
+        assert result.exit_code == 0
+        kwargs = client.get_datasets.call_args.kwargs
+        assert kwargs["filters"] == [{"col": "id", "opr": "eq", "value": 1}]
+        assert kwargs["fetch_all"] is True
+
+    @patch(PATCH_SPINNER)
+    @patch(PATCH_CLIENT)
+    @patch(PATCH_CTX)
+    def test_ids_filter_server_side(self, mock_ctx_cls, mock_client_cls, mock_spinner):
+        """--ids is pushed to the API as an in filter over the parsed id list."""
+        cm, sp = _make_spinner_mock()
+        mock_spinner.return_value = cm
+        mock_ctx_cls.return_value = MagicMock()
+        client = MagicMock()
+        mock_client_cls.from_context.return_value = client
+        client.get_datasets.return_value = SAMPLE_DATASETS
+
+        result = runner.invoke(app, ["list", "--ids", "1,2", "--json"])
+        assert result.exit_code == 0
+        kwargs = client.get_datasets.call_args.kwargs
+        assert kwargs["filters"] == [{"col": "id", "opr": "in", "value": [1, 2]}]
+        assert kwargs["fetch_all"] is True
+
+    @patch(PATCH_SPINNER)
+    @patch(PATCH_CLIENT)
+    @patch(PATCH_CTX)
+    def test_ids_filter_invalid_value(self, mock_ctx_cls, mock_client_cls, mock_spinner):
+        """Malformed --ids fails cleanly with a readable 'Invalid ID format' message."""
+        cm, sp = _make_spinner_mock()
+        mock_spinner.return_value = cm
+        mock_ctx_cls.return_value = MagicMock()
+        client = MagicMock()
+        mock_client_cls.from_context.return_value = client
+
+        result = runner.invoke(app, ["list", "--ids", "1,abc"])
+        assert result.exit_code == 1
+        assert "Invalid ID format" in result.output
+
+    @patch(PATCH_SPINNER)
+    @patch(PATCH_CLIENT)
+    @patch(PATCH_CTX)
+    def test_database_id_filter_server_side(self, mock_ctx_cls, mock_client_cls, mock_spinner):
+        """--database-id is pushed to the API as a rel_o_m filter on `database`."""
+        cm, sp = _make_spinner_mock()
+        mock_spinner.return_value = cm
+        mock_ctx_cls.return_value = MagicMock()
+        client = MagicMock()
+        mock_client_cls.from_context.return_value = client
+        client.get_datasets.return_value = [SAMPLE_DATASETS[0]]
+
+        result = runner.invoke(app, ["list", "--database-id", "1", "--json"])
+        assert result.exit_code == 0
+        kwargs = client.get_datasets.call_args.kwargs
+        assert kwargs["filters"] == [{"col": "database", "opr": "rel_o_m", "value": 1}]
+        assert kwargs["fetch_all"] is True
+
+    @patch(PATCH_SPINNER)
+    @patch(PATCH_CLIENT)
+    @patch(PATCH_CTX)
+    def test_no_filters_single_page(self, mock_ctx_cls, mock_client_cls, mock_spinner):
+        """Without filters, no server-side filters are sent and fetch_all stays off."""
+        cm, sp = _make_spinner_mock()
+        mock_spinner.return_value = cm
+        mock_ctx_cls.return_value = MagicMock()
+        client = MagicMock()
+        mock_client_cls.from_context.return_value = client
+        client.get_datasets.return_value = SAMPLE_DATASETS
+
+        result = runner.invoke(app, ["list", "--json"])
+        assert result.exit_code == 0
+        kwargs = client.get_datasets.call_args.kwargs
+        assert kwargs["filters"] == []
+        assert kwargs["fetch_all"] is False
+
+    @patch(PATCH_SPINNER)
+    @patch(PATCH_CLIENT)
+    @patch(PATCH_CTX)
+    def test_filter_with_limit(self, mock_ctx_cls, mock_client_cls, mock_spinner):
+        """Limit is applied after server-side filtering across the full result set."""
+        cm, sp = _make_spinner_mock()
+        mock_spinner.return_value = cm
+        mock_ctx_cls.return_value = MagicMock()
+        client = MagicMock()
+        mock_client_cls.from_context.return_value = client
+        # Server returns both rows for database 99; --limit 1 should trim to one
+        client.get_datasets.return_value = SAMPLE_DATASETS
+
+        result = runner.invoke(app, ["list", "--database-id", "99", "--limit", "1", "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert len(parsed) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`sup dataset list` declared `--id`, `--ids`, and `--database-id` options but never used them — every invocation returned **all** datasets regardless of the filters passed. A prior server-side-search refactor (`bbf2b7f`) wired up `--search` but dropped the filtering logic for these three flags, leaving them in the signature as dead options the help text still advertises.

- Before

<img width="700" height="551" alt="Screenshot 2026-06-03 131902" src="https://github.com/user-attachments/assets/6f130f4c-f204-479b-93ba-ced9276a2c00" />

- After

<img width="570" height="187" alt="Screenshot 2026-06-03 132747" src="https://github.com/user-attachments/assets/a85b7776-a298-40ed-a0d1-10dfca11f911" />

### Reproduce
- `sup dataset list --id 3` → returns all datasets instead of just dataset 3
- `sup dataset list --database-id 1` → returns all datasets instead of those in database 1

(`--id` works on `sup chart list`, which is why the bug looked dataset-specific.)

## Fix

Push the filters to the Superset API instead of filtering after the fact, and paginate the full result set so matches aren't capped to the first page.

**`src/sup/commands/dataset.py`** — build server-side filter dicts:
- `--id` → `{col: id, opr: eq}`
- `--ids` → `{col: id, opr: in}` (parsed via the existing `UniversalFilters.parse_ids`)
- `--database-id` → `{col: database, opr: rel_o_m}`

Operator/column choices were verified against the live API — note `database_id eq` returns HTTP 400, so `database` + `rel_o_m` is required. `--limit` is applied after filtering.

**`src/sup/clients/superset.py`** — `SupSupersetClient.get_datasets` gains `filters` and `fetch_all`. When filtering, it paginates until the API returns an empty page (`page_size = MAX_PAGE_SIZE`), so matches beyond the first 50 aren't silently dropped in large workspaces. The default single-page fast path is unchanged, so unfiltered `dataset list` and other callers behave exactly as before.

## Testing

- New `tests/sup/clients/superset_test.py`: single-page default, full pagination until empty, combined filters + text search, error handling.
- New command tests asserting the server-side filter contract for `--id`/`--ids`/
  `--database-id`, the no-filter path, limit-after-filter, and a clean error on malformed `--ids`.
- Verified end-to-end against a live workspace, including a forced small page size proving results span multiple pages correctly. 53 tests pass.

## Out of scope (follow-ups)

- `sup chart list` / `dashboard list` have the same single-page-50 limitation in  `get_charts`/`get_dashboards` — not addressed here.
- `dataset list` still ignores other declared flags (`--schema`, `--mine`, `--order`, etc.); only the three filters in the ticket are wired up.
