### PR TITLE
fix(sup): scope --workspace-id filter without overwriting persistent workspace state

### DIFF
--- a/src/sup/clients/superset.py
+++ b/src/sup/clients/superset.py
@@ -32,7 +32,14 @@ class SupSupersetClient:
         ctx: SupContext,
         workspace_id: Optional[int] = None,
     ) -> "SupSupersetClient":
-        """Create Superset client from sup configuration context."""
+        """Create Superset client from sup configuration context.
+
+        When ``workspace_id`` resolves to a workspace other than the persistent
+        active one (e.g. via a ``--workspace-id`` filter flag), it scopes this
+        client only and is never written back to the persistent state. The
+        active workspace in ``.sup/state.yml`` is changed solely by
+        ``sup workspace use`` / ``sup config set workspace-id``.
+        """
         # Get workspace ID from context if not provided
         if workspace_id is None:
             workspace_id = ctx.get_workspace_id()
@@ -86,8 +93,11 @@ class SupSupersetClient:
                 )
                 raise ValueError(f"No hostname for workspace {workspace_id}")
 
-            # Cache the hostname for future use
-            ctx.set_workspace_context(workspace_id, hostname=hostname)
+            # Cache the hostname for future use, but only when this IS the
+            # persistent active workspace. A scoped --workspace-id filter that
+            # points elsewhere must not be written back to .sup/state.yml.
+            if workspace_id == current_workspace_id:
+                ctx.set_workspace_context(workspace_id, hostname=hostname)
 
         workspace_url = f"https://{hostname}/"
 

--- a/tests/sup/clients/superset_test.py
+++ b/tests/sup/clients/superset_test.py
@@ -1,6 +1,7 @@
 """Tests for SupSupersetClient.get_datasets server-side filtering & pagination."""
 
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import prison
 from yarl import URL
@@ -87,3 +88,86 @@ def test_error_returns_empty_list():
     client.client = inner
 
     assert client.get_datasets(silent=True) == []
+
+
+def _ctx_for_from_context(current_workspace_id):
+    """A SupContext mock for from_context with no cached hostname.
+
+    The active workspace is ``current_workspace_id`` and the hostname cache is
+    empty, forcing from_context to resolve the hostname via the Preset API.
+    """
+    ctx = MagicMock()
+    ctx.get_workspace_id.return_value = current_workspace_id
+    ctx.get_workspace_hostname.return_value = None
+    return ctx
+
+
+@contextmanager
+def _patched_from_context(workspaces):
+    """Patch the Preset/auth/client collaborators from_context resolves through.
+
+    ``workspaces`` is the list returned by get_all_workspaces (the hostname
+    resolution source).
+    """
+    preset_client = MagicMock()
+    preset_client.get_all_workspaces.return_value = workspaces
+
+    with patch(
+        "sup.clients.preset.SupPresetClient.from_context",
+        return_value=preset_client,
+    ), patch(
+        "sup.clients.superset.SupPresetAuth.from_sup_config",
+        return_value=MagicMock(),
+    ), patch(
+        "sup.clients.superset.SupersetClient",
+        return_value=MagicMock(),
+    ):
+        yield
+
+
+def test_from_context_scoped_workspace_id_does_not_persist():
+    """A --workspace-id filter pointing elsewhere must not touch state.yml.
+
+    Regression: passing a workspace id as a filter used to overwrite the
+    persistent current workspace via set_workspace_context.
+    """
+    ctx = _ctx_for_from_context(current_workspace_id=100)
+
+    with _patched_from_context([{"id": 200, "hostname": "ws200.example.com"}]):
+        client = SupSupersetClient.from_context(ctx, workspace_id=200)
+
+    assert client.workspace_url == "https://ws200.example.com/"
+    ctx.set_workspace_context.assert_not_called()
+
+
+def test_from_context_default_workspace_caches_hostname():
+    """Without an explicit id, the active workspace's hostname is cached."""
+    ctx = _ctx_for_from_context(current_workspace_id=100)
+
+    with _patched_from_context([{"id": 100, "hostname": "ws100.example.com"}]):
+        client = SupSupersetClient.from_context(ctx)
+
+    assert client.workspace_url == "https://ws100.example.com/"
+    ctx.set_workspace_context.assert_called_once_with(
+        100,
+        hostname="ws100.example.com",
+    )
+
+
+def test_from_context_explicit_active_workspace_id_caches_hostname():
+    """An explicit id equal to the active workspace still warms the cache.
+
+    Callers such as `sup sql` pre-resolve the workspace id and pass it
+    positionally even with no --workspace-id flag; that path must keep caching
+    the active workspace's hostname rather than re-hitting the Preset API.
+    """
+    ctx = _ctx_for_from_context(current_workspace_id=100)
+
+    with _patched_from_context([{"id": 100, "hostname": "ws100.example.com"}]):
+        client = SupSupersetClient.from_context(ctx, workspace_id=100)
+
+    assert client.workspace_url == "https://ws100.example.com/"
+    ctx.set_workspace_context.assert_called_once_with(
+        100,
+        hostname="ws100.example.com",
+    )


### PR DESCRIPTION
## Summary

Using `--workspace-id` as a one-time filter (e.g. `sup dataset list --workspace-id <B>`) permanently overwrote `current_workspace_id` in `~/.sup/state.yml`, causing all subsequent commands to run against the filtered workspace.

The root cause is in `SupSupersetClient.from_context`, the single entry point every command uses to build a Superset client. 

When resolving a workspace's hostname, it called `set_workspace_context(...)` unconditionally — persisting the filtered workspace as the new active one.

This change gates the hostname cache write on `workspace_id == current_workspace_id`, so a `--workspace-id` filter pointing at a *different* workspace scopes only that command, while the active workspace's hostname is still cached.

## How to reproduce the bug

1. `sup config set workspace-id <A>` → confirm `current_workspace_id` is A in `~/.sup/state.yml`
2. `sup dataset list --workspace-id <B>`
3. `cat ~/.sup/state.yml` → `current_workspace_id` is now permanently B ❌

After this fix, step 3 still shows A — the filter is scoped to that one command.

## Changes

- **`src/sup/clients/superset.py`** — gate the hostname cache write on `workspace_id == current_workspace_id` instead of writing it unconditionally. Because the fix is centralized in `from_context`, every entity command that accepts `--workspace-id` (`dataset`, `chart`, `dashboard`, `database`, `sql`, `query`, `user`, `sync`, …) is fixed at once. The two intentional state-mutating commands — `sup workspace use` and `sup config set workspace-id` — go through separate call sites and are unaffected.
- **`tests/sup/clients/superset_test.py`** — regression tests for three paths:
  - scoped filter (different id) → does **not** persist
  - default (no flag) → caches the active workspace's hostname
  - explicit id equal to the active workspace → still caches (the path `sup sql` hits, since it pre-resolves the id and passes it positionally even with no flag)

## Behavior preserved

The fix keeps hostname caching working for callers that pre-resolve the workspace id (e.g. `sup sql`, `sync`), avoiding an extra Preset API round-trip on every invocation — a regression an earlier `is_explicit_override` approach would have introduced.

## Testing

- `pytest tests/sup/clients/superset_test.py` — all 7 tests pass
- ruff, ruff-format, and mypy pass via pre-commit

## Out of scope

A separate pre-existing issue — `set_workspace_context(persist=True)` discarding the resolved hostname for global-only configs — is orthogonal to this fix and left for a follow-up.
