### PR TITLE
chore: modernize PyPI publish workflow (OIDC trusted publishing)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,10 +1,8 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+# This workflow uploads a Python package to PyPI when a release is published.
+# It uses PyPI Trusted Publishing (OIDC) via pypa/gh-action-pypi-publish,
+# so no API token secret is required.
+# For more information see:
+# https://docs.pypi.org/trusted-publishers/
 
 name: Upload Python Package
 
@@ -12,15 +10,20 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing (OIDC)
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -30,7 +33,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Modernizes `.github/workflows/python-publish.yml`:

- **Trusted Publishing (OIDC)** instead of an API token. Drops `user: __token__` / `password: ${{ secrets.PYPI_API_TOKEN }}`; adds `id-token: write` permission and a `pypi` deployment environment. No long-lived secret to rotate/leak.
- **Updated actions:** `checkout@v2`→`v4`, `setup-python@v2`→`v5`, and `pypa/gh-action-pypi-publish` pinned-SHA → `release/v1`.
- **Least-privilege:** top-level `contents: read`, `id-token: write` scoped to the deploy job only.
- Fixed the stale "using Twine" header comment.

## Why

twine is not used directly — `gh-action-pypi-publish` runs it internally — so nothing twine-related is needed in the repo. The token-based flow was the only remaining thing to modernize.

## Testing

Publish workflows only run on `release: published`, so this can't be exercised by CI — verified by inspection against the [PyPI trusted-publishing docs](https://docs.pypi.org/trusted-publishers/). First real validation is the next release.