### PR TITLE
chore: update changelog for v0.1.6 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 Next
 ====
 
+Version 0.1.6 - 2026-06-23
+===========================
+
+- Relaxed the SQLAlchemy pin to support SQLAlchemy 2.x and switched to ``URL.create`` (`#58 <https://github.com/preset-io/superset-sup/pull/58>`_).
+- Modernized the PyPI publish workflow to use OIDC trusted publishing and refreshed action versions (`#59 <https://github.com/preset-io/superset-sup/pull/59>`_).
+
 Version 0.1.5 - 2026-06-17
 ===========================
 


### PR DESCRIPTION
## Summary

Adds the `v0.1.6` changelog section covering the changes merged since `v0.1.5`:

- SQLAlchemy 2.x support (#58)
- PyPI publish workflow modernized to OIDC trusted publishing (#59)

## Testing

Docs/metadata-only change — no code paths affected.